### PR TITLE
Stream A: identity + feedback contract (UIDs, --as, --format json, PostToolUse hook)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/post-tool-use-hook.sh",
+            "timeout": 3,
+            "async": false
+          }
+        ]
+      }
     ]
   }
 }

--- a/bin/post-tool-use-hook.sh
+++ b/bin/post-tool-use-hook.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Workplanner PostToolUse hook.
+#
+# Secondary feedback channel (per Q2 / Stream A): when the LLM invokes a
+# Bash tool whose command is a `wpl` call, re-inject the current session
+# state into the next turn's context. The primary channel is the full
+# compact task list on stdout of every mutating command; this hook is
+# defense-in-depth for cases where the assistant's model of state drifts
+# across turns anyway (long outputs, compaction, or third-party tools
+# elbowing the stdout off the visible context).
+#
+# Protocol: stdin carries hook JSON with tool_name and tool_input.command.
+# Output: JSON on stdout shaped per Claude Code hook spec:
+#   {"hookSpecificOutput": {"hookEventName": "PostToolUse",
+#                           "additionalContext": "..."}}
+# If not a wpl invocation, exit 0 silently.
+
+set -eu
+
+input=$(cat)
+
+# Require jq for reliable parsing. If missing, fail open (emit nothing).
+command -v jq >/dev/null 2>&1 || exit 0
+
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty')
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+[ "$tool_name" = "Bash" ] || exit 0
+[ -n "$cmd" ] || exit 0
+
+# Recognize either a bare `wpl ...` call or the explicit wrapper path.
+# Match conservatively: first token is `wpl` or ends with `/wpl`,
+# or the command contains the wpl wrapper path substring.
+first_token=$(printf '%s' "$cmd" | awk '{print $1}')
+is_wpl=0
+case "$first_token" in
+    wpl|*/wpl) is_wpl=1 ;;
+esac
+case "$cmd" in
+    */.workplanner/bin/wpl*) is_wpl=1 ;;
+    */workplanner/bin/transition.py*) is_wpl=1 ;;
+esac
+[ "$is_wpl" = "1" ] || exit 0
+
+# Resolve the wpl wrapper. Prefer the per-user wrapper path; fall back
+# to PATH resolution. Both are fine.
+WPL_BIN="${WPL_BIN:-$HOME/.workplanner/bin/wpl}"
+if [ ! -x "$WPL_BIN" ]; then
+    WPL_BIN=$(command -v wpl 2>/dev/null || true)
+fi
+[ -n "${WPL_BIN:-}" ] && [ -x "$WPL_BIN" ] || exit 0
+
+# Pull compact status as JSON, then fold down to a short context block.
+# Keep the injection under ~500 tokens (roughly <2KB of ASCII).
+status_json=$("$WPL_BIN" --format json status 2>/dev/null || true)
+[ -n "$status_json" ] || exit 0
+
+# Transform JSON → compact markdown-ish text, capped in line count.
+# The inline Python script reads the JSON payload from stdin (piped in from
+# $status_json). We use `-c` rather than a heredoc so stdin stays free for
+# the pipe input.
+summary=$(printf '%s' "$status_json" | python3 -c '
+import json, sys
+
+try:
+    s = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+lines = ["Workplanner session state (post-wpl injection):"]
+counts = s.get("counts", {})
+lines.append(
+    "  Done: {}/{} | ~{}m left | EOD: {}".format(
+        counts.get("done", 0),
+        counts.get("total", 0),
+        counts.get("remaining_min", 0),
+        s.get("eod_target", "?"),
+    )
+)
+
+cur = s.get("current_task")
+if cur:
+    lines.append(
+        "  Current: {} {} \"{}\" (~{}m)".format(
+            cur.get("tid"),
+            cur.get("uid"),
+            cur.get("title"),
+            cur.get("estimate_min", "?"),
+        )
+    )
+else:
+    lines.append("  Current: (none)")
+
+glyphs = {
+    "in_progress": "▶",
+    "done":        "✓",
+    "blocked":     "⚠",
+    "deferred":    "↷",
+    "pending":     " ",
+}
+
+tasks = s.get("tasks") or []
+# Cap at 15 tasks to stay well under ~500 tokens.
+if tasks:
+    lines.append("  Tasks:")
+    for t in tasks[:15]:
+        g = glyphs.get(t.get("status", "pending"), " ")
+        lines.append(
+            "    [{}] {}  {}  \"{}\"".format(
+                g, t.get("tid"), t.get("uid"), t.get("title")
+            )
+        )
+    if len(tasks) > 15:
+        lines.append("    ... {} more".format(len(tasks) - 15))
+
+print("\n".join(lines))
+' 2>/dev/null || true)
+
+[ -n "$summary" ] || exit 0
+
+# Emit hook output as JSON. jq -Rs builds a valid JSON string from the
+# summary; the jq expression wraps it in the required hook-response
+# envelope.
+printf '%s' "$summary" | jq -Rs '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: .
+  }
+}'

--- a/bin/render_dashboard.py
+++ b/bin/render_dashboard.py
@@ -17,7 +17,7 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
-WPL_ROOT = Path.home() / ".workplanner"
+WPL_ROOT = Path(os.environ["WPL_ROOT"]) if os.environ.get("WPL_ROOT") else Path.home() / ".workplanner"
 
 
 def resolve_active_profile():

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-WPL_ROOT = Path.home() / ".workplanner"
+WPL_ROOT = Path(os.environ["WPL_ROOT"]) if os.environ.get("WPL_ROOT") else Path.home() / ".workplanner"
 
 
 def resolve_profile_root():
@@ -230,8 +230,9 @@ def render():
 
 
 def fail(msg):
-    print(f"error: {msg}", file=sys.stderr)
-    sys.exit(1)
+    # Route through emit_error so JSON mode emits structured errors.
+    # Falls back to the historical "error: ..." line in text mode.
+    emit_error(msg)
 
 
 def now_hhmm():
@@ -449,6 +450,216 @@ def status_line(session, config=None):
         )
 
 
+# ── Output format / shared formatter ─────────────────────────────────
+
+# Set by main() from the top-level --format argument. Commands read it
+# to decide between glyph-friendly text output and a structured JSON
+# response. Default "text" preserves backward-compatible behaviour.
+OUTPUT_FORMAT = "text"
+
+
+STATUS_GLYPH = {
+    "in_progress": "▶",
+    "done":        "✓",
+    "blocked":     "⚠",
+    "deferred":    "↷",
+    "pending":     " ",
+}
+
+
+def _task_record(idx, task):
+    """Compact dict representation of a task for JSON emission."""
+    return {
+        "tid": tid(idx),
+        "index": idx,
+        "uid": task.get("uid"),
+        "title": task.get("title"),
+        "status": task.get("status"),
+        "estimate_min": task.get("estimate_min"),
+        "actual_min": task.get("actual_min"),
+        "source": task.get("source"),
+        "ref": task.get("ref"),
+        "url": task.get("url"),
+        "notes": task.get("notes"),
+        "started_at": task.get("started_at"),
+        "finished_at": task.get("finished_at"),
+        "dispatched": bool(task.get("dispatched")),
+        "deferral_count": task.get("deferral_count", 0),
+        "parent": task.get("parent"),
+    }
+
+
+def session_records(session):
+    """Return per-task records list for JSON output."""
+    tasks = session.get("tasks", [])
+    return [_task_record(i, t) for i, t in enumerate(tasks)]
+
+
+def format_task_list(session, config=None):
+    """Return a list of lines representing the full compact task list.
+
+    Format per Stream A (Q1/Q8): every task on its own line with glyph,
+    display ID, UID, title, estimate/actual, and source/ref. Footer line
+    matches the existing remaining_summary/status_line shape.
+
+    Shared by every mutating command so the stdout channel carries the
+    full post-mutation state. Do not duplicate formatting elsewhere.
+    """
+    tasks = session.get("tasks", [])
+    cur_idx = session.get("current_task_index")
+    lines = []
+
+    for i, t in enumerate(tasks):
+        status = t.get("status", "pending")
+        if i == cur_idx and status == "in_progress":
+            glyph = STATUS_GLYPH["in_progress"]
+        else:
+            glyph = STATUS_GLYPH.get(status, " ")
+
+        uid = (t.get("uid") or "?")[:8]
+        title = t.get("title") or "?"
+
+        est = t.get("estimate_min")
+        actual = t.get("actual_min")
+        if status == "done":
+            if actual is not None and est:
+                time_str = f"({actual}m/{est}m)"
+            elif actual is not None:
+                time_str = f"({actual}m)"
+            elif est:
+                time_str = f"(~{est}m)"
+            else:
+                time_str = ""
+        else:
+            time_str = f"(~{est}m)" if est else ""
+
+        ref = t.get("ref")
+        source = t.get("source")
+        if ref:
+            src_str = f" [{ref}]"
+        elif source and source != "manual":
+            src_str = f" [{source}]"
+        else:
+            src_str = ""
+
+        dispatch_str = " (dispatched)" if t.get("dispatched") else ""
+        parent = t.get("parent")
+        parent_str = f" (child of {tid(parent)})" if parent is not None else ""
+
+        line = f"  [{glyph}] {tid(i)}  {uid}  {title}  {time_str}{dispatch_str}{parent_str}{src_str}".rstrip()
+        lines.append(line)
+
+    done_count = sum(1 for t in tasks if t.get("status") == "done")
+    total_count = len(tasks)
+    remaining = sum(
+        t.get("estimate_min", 0) or 0
+        for t in tasks
+        if t.get("status") in ("pending", "in_progress", "blocked")
+    )
+    eod = session.get("eod_target", "18:00")
+    footer = (
+        f"  Done: {done_count}/{total_count}"
+        f" | ~{fmt_duration(remaining)} left"
+        f" | EOD: {eod}"
+    )
+    if not lines:
+        lines.append("  (no tasks)")
+    lines.append(footer)
+    return lines
+
+
+def print_task_list(session, config=None):
+    """Print the full compact task list to stdout."""
+    for line in format_task_list(session, config):
+        print(line)
+
+
+def _status_payload(session, config=None):
+    """Build the structured status payload used by --format json."""
+    tasks = session.get("tasks", [])
+    idx, task = current_task(session)
+    eod = session.get("eod_target", "18:00")
+    today = local_today(config)
+    tz_name = (config or {}).get("timezone", "")
+
+    done_count = sum(1 for t in tasks if t.get("status") == "done")
+    total_count = len(tasks)
+    remaining = sum(
+        t.get("estimate_min", 0) or 0
+        for t in tasks
+        if t.get("status") in ("pending", "in_progress", "blocked")
+    )
+
+    def records_by_status(want):
+        return [_task_record(i, t) for i, t in enumerate(tasks)
+                if t.get("status") == want]
+
+    current = _task_record(idx, task) if task else None
+
+    return {
+        "date": today.isoformat(),
+        "timezone": tz_name,
+        "eod_target": eod,
+        "checkpoint": session.get("checkpoint"),
+        "current_task": current,
+        "current_task_index": idx,
+        "tasks": session_records(session),
+        "pending": records_by_status("pending"),
+        "done": records_by_status("done"),
+        "blocked": records_by_status("blocked"),
+        "deferred": records_by_status("deferred"),
+        "in_progress": records_by_status("in_progress"),
+        "counts": {
+            "done": done_count,
+            "total": total_count,
+            "remaining_min": remaining,
+        },
+    }
+
+
+def emit_mutation(action, session, affected=None, config=None, human_line=None):
+    """Emit a mutation's stdout — text (one-liner + full list) or JSON.
+
+    `action` is the wpl subcommand that ran. `affected` is a list of
+    (index, task) tuples whose identity should be echoed in the JSON
+    response. `human_line` is the one-line confirmation printed first
+    in text mode.
+    """
+    if OUTPUT_FORMAT == "json":
+        payload = {
+            "result": "ok",
+            "action": action,
+            "affected": [
+                {"uid": t.get("uid"), "tid": tid(i), "title": t.get("title")}
+                for (i, t) in (affected or [])
+            ],
+            "session": _status_payload(session, config),
+        }
+        print(json.dumps(payload))
+        return
+    if human_line:
+        print(human_line)
+    print_task_list(session, config)
+
+
+def emit_error(msg, **extra):
+    """Emit an error — text to stderr or JSON to stderr, then exit 1."""
+    if OUTPUT_FORMAT == "json":
+        payload = {"error": msg}
+        payload.update(extra)
+        print(json.dumps(payload), file=sys.stderr)
+    else:
+        print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _title_matches(actual, echoed):
+    """Case-insensitive, whitespace-tolerant title comparison for --as."""
+    def norm(s):
+        return " ".join((s or "").lower().split())
+    return norm(actual) == norm(echoed)
+
+
 # ── Commands ─────────────────────────────────────────────────────────
 
 
@@ -459,6 +670,19 @@ def cmd_done(args):
         fail("No current task.")
     if task["status"] != "in_progress":
         fail(f"{tid(idx)} is {task['status']}, not in_progress.")
+
+    # Echo-check: --as "<title>" must match the target task's title.
+    echoed = getattr(args, "as_title", None)
+    if echoed is not None and not _title_matches(task.get("title"), echoed):
+        emit_error(
+            f"--as echoed title does not match target task. "
+            f"Expected \"{task.get('title')}\" (uid {task.get('uid')}), "
+            f"got \"{echoed}\".",
+            expected_title=task.get("title"),
+            expected_uid=task.get("uid"),
+            echoed=echoed,
+            tid=tid(idx),
+        )
 
     if task.get("dispatched"):
         print(f"warning: {tid(idx)} is dispatched to another session.", file=sys.stderr)
@@ -475,7 +699,9 @@ def cmd_done(args):
     render()
 
     est = task.get("estimate_min", 0)
-    print(f"\u2713 {tid(idx)} done ({actual}m/{est}m est). [{remaining_summary(session)}]")
+    human = f"\u2713 {tid(idx)} done ({actual}m/{est}m est). [{remaining_summary(session)}]"
+    emit_mutation("done", session, affected=[(idx, task)],
+                  config=load_config(), human_line=human)
 
 
 def cmd_blocked(args):
@@ -502,7 +728,8 @@ def cmd_blocked(args):
     if reason:
         line += f" ({reason})"
     line += f" [{remaining_summary(session)}]"
-    print(line)
+    emit_mutation("blocked", session, affected=[(idx, task)],
+                  config=load_config(), human_line=line)
 
 
 def cmd_defer(args):
@@ -552,7 +779,9 @@ def cmd_defer(args):
     save_session(session)
     render()
 
-    print(f"\u21b7 {tid(idx)} deferred ({count}x). [{remaining_summary(session)}]")
+    human = f"\u21b7 {tid(idx)} deferred ({count}x). [{remaining_summary(session)}]"
+    emit_mutation("defer", session, affected=[(idx, task)],
+                  config=load_config(), human_line=human)
 
 
 def cmd_add(args):
@@ -631,7 +860,9 @@ def cmd_add(args):
 
     status_tag = " (done)" if args.done else ""
     parent_tag = f" (child of {tid(new_task['parent'])})" if "parent" in new_task else ""
-    print(f"+ {tid(insert_pos)} added: \"{title}\" (~{est}m){status_tag}{parent_tag}. [{remaining_summary(session)}]")
+    human = f"+ {tid(insert_pos)} added: \"{title}\" (~{est}m){status_tag}{parent_tag}. [{remaining_summary(session)}]"
+    emit_mutation("add", session, affected=[(insert_pos, new_task)],
+                  config=load_config(), human_line=human)
 
 
 def cmd_switch(args):
@@ -673,7 +904,8 @@ def cmd_switch(args):
         prev_task = session["tasks"][prev_idx]
         if prev_task.get("status") == "in_progress":
             line += f". {tid(prev_idx)} still in_progress (--no-pause)."
-    print(line)
+    emit_mutation("switch", session, affected=[(target, task)],
+                  config=load_config(), human_line=line)
 
 
 def cmd_move(args):
@@ -686,7 +918,9 @@ def cmd_move(args):
     dest = max(0, min(dest, len(tasks)))
 
     if source == dest:
-        print(f"{tid(source)} is already at that position.")
+        human = f"{tid(source)} is already at that position."
+        emit_mutation("move", session, affected=[(source, tasks[source])],
+                      config=load_config(), human_line=human)
         return
 
     # Pop from source, then insert at dest (the desired final position).
@@ -714,7 +948,9 @@ def cmd_move(args):
     save_session(session)
     render()
 
-    print(f"\u2194 {tid(dest)} \u2014 {moved['title']} (moved from {tid(source)})")
+    human = f"\u2194 {tid(dest)} \u2014 {moved['title']} (moved from {tid(source)})"
+    emit_mutation("move", session, affected=[(dest, moved)],
+                  config=load_config(), human_line=human)
 
 
 def cmd_remove(args):
@@ -724,7 +960,21 @@ def cmd_remove(args):
     tasks = session.get("tasks", [])
     cur_idx = session.get("current_task_index")
 
+    # Echo-check: --as "<title>" must match the target task's title.
+    echoed = getattr(args, "as_title", None)
+    if echoed is not None and not _title_matches(task.get("title"), echoed):
+        emit_error(
+            f"--as echoed title does not match target task. "
+            f"Expected \"{task.get('title')}\" (uid {task.get('uid')}), "
+            f"got \"{echoed}\".",
+            expected_title=task.get("title"),
+            expected_uid=task.get("uid"),
+            echoed=echoed,
+            tid=tid(target),
+        )
+
     title = task["title"]
+    removed_snapshot = dict(task)
     tasks.pop(target)
 
     # Adjust current_task_index
@@ -739,7 +989,8 @@ def cmd_remove(args):
     render()
 
     line = f"\u2716 {tid(target)} removed: \"{title}\". [{remaining_summary(session)}]"
-    print(line)
+    emit_mutation("remove", session, affected=[(target, removed_snapshot)],
+                  config=load_config(), human_line=line)
 
 
 def cmd_dispatch(args):
@@ -758,7 +1009,9 @@ def cmd_dispatch(args):
     save_session(session)
     render()
 
-    print(f"\u21c4 {tid(target)} dispatched \u2014 {task['title']}")
+    human = f"\u21c4 {tid(target)} dispatched \u2014 {task['title']}"
+    emit_mutation("dispatch", session, affected=[(target, task)],
+                  config=load_config(), human_line=human)
 
 
 def _move_task_to_backlog(session, idx, target_date=None, not_before=None, deadline=None, tags=None):
@@ -801,7 +1054,9 @@ def _move_task_to_backlog(session, idx, target_date=None, not_before=None, deadl
 
     date_tag = f" (target: {target_date})" if target_date else ""
     deadline_tag = f" (deadline: {deadline})" if deadline else ""
-    print(f"\u21b3 {tid(idx)} \u2192 backlog: \"{title}\"{date_tag}{deadline_tag}. [{remaining_summary(session)}]")
+    human = f"\u21b3 {tid(idx)} \u2192 backlog: \"{title}\"{date_tag}{deadline_tag}. [{remaining_summary(session)}]"
+    emit_mutation("backlog:from-session", session, affected=[(idx, task)],
+                  config=load_config(), human_line=human)
 
 
 def cmd_backlog(args):
@@ -879,7 +1134,19 @@ def _backlog_add(args):
     if bl_deadline:
         date_info.append(f"deadline: {bl_deadline}")
     date_str = f" ({', '.join(date_info)})" if date_info else ""
-    print(f"+ backlog: \"{title}\" (~{args.est}m){date_str}. [backlog: {len(backlog['items'])} items]")
+    human = f"+ backlog: \"{title}\" (~{args.est}m){date_str}. [backlog: {len(backlog['items'])} items]"
+    # backlog --add does not mutate session; re-load session so the full task list
+    # reflects the unchanged plan (LLM feedback loop per Stream A).
+    try:
+        _session = load_session()
+        emit_mutation("backlog:add", _session, affected=[], config=load_config(), human_line=human)
+    except SystemExit:
+        # No session yet — fall back to just the human line.
+        if OUTPUT_FORMAT == "json":
+            print(json.dumps({"result": "ok", "action": "backlog:add",
+                              "backlog_count": len(backlog['items'])}))
+        else:
+            print(human)
 
 
 def _backlog_from_session(args):
@@ -1016,7 +1283,9 @@ def _backlog_promote(args):
     save_session(session)
     render()
 
-    print(f"\u2191 {tid(insert_pos)} promoted from backlog: \"{item['title']}\". [{remaining_summary(session)}]")
+    human = f"\u2191 {tid(insert_pos)} promoted from backlog: \"{item['title']}\". [{remaining_summary(session)}]"
+    emit_mutation("backlog:promote", session, affected=[(insert_pos, new_task)],
+                  config=load_config(), human_line=human)
 
 
 def _backlog_drop(args):
@@ -1033,7 +1302,22 @@ def _backlog_drop(args):
 
     dropped = items.pop(found)
     save_backlog(backlog)
-    print(f"\u2716 dropped from backlog: \"{dropped['title']}\". [backlog: {len(items)} items]")
+    human = f"\u2716 dropped from backlog: \"{dropped['title']}\". [backlog: {len(items)} items]"
+    if OUTPUT_FORMAT == "json":
+        try:
+            _session = load_session()
+            emit_mutation("backlog:drop", _session, affected=[], config=load_config(), human_line=human)
+        except SystemExit:
+            print(json.dumps({"result": "ok", "action": "backlog:drop",
+                              "backlog_count": len(items)}))
+    else:
+        print(human)
+        # Session unchanged, but a follow-up compact list keeps the LLM's model warm.
+        try:
+            _session = load_session()
+            print_task_list(_session, load_config())
+        except SystemExit:
+            pass
 
 
 def _backlog_edit(args):
@@ -1081,7 +1365,20 @@ def _backlog_edit(args):
         fail("Nothing to edit. Use --target, --deadline, --not-before, --tag, --notes, or --est.")
 
     save_backlog(backlog)
-    print(f"\u270e backlog \"{found['title']}\": {', '.join(changed)}")
+    human = f"\u270e backlog \"{found['title']}\": {', '.join(changed)}"
+    if OUTPUT_FORMAT == "json":
+        try:
+            _session = load_session()
+            emit_mutation("backlog:edit", _session, affected=[], config=load_config(), human_line=human)
+        except SystemExit:
+            print(json.dumps({"result": "ok", "action": "backlog:edit"}))
+    else:
+        print(human)
+        try:
+            _session = load_session()
+            print_task_list(_session, load_config())
+        except SystemExit:
+            pass
 
 
 def cmd_reckon(args):
@@ -1101,11 +1398,14 @@ def cmd_reckon(args):
         save_session(session)
         render()
         count = task.get("deferral_count", 0)
-        print(f"\u21b7 {tid(idx)} deferred ({count}x, keeping). [{remaining_summary(session)}]")
+        human = f"\u21b7 {tid(idx)} deferred ({count}x, keeping). [{remaining_summary(session)}]"
+        emit_mutation("reckon:keep", session, affected=[(idx, task)],
+                      config=load_config(), human_line=human)
 
     elif choice in ("x", "drop"):
         title = task["title"]
         tasks = session.get("tasks", [])
+        dropped_snapshot = dict(task)
         tasks.pop(idx)
         cur_idx = session.get("current_task_index")
         if cur_idx is not None:
@@ -1115,7 +1415,9 @@ def cmd_reckon(args):
                 session["current_task_index"] = cur_idx - 1
         save_session(session)
         render()
-        print(f"\u2716 {tid(idx)} dropped: \"{title}\". [{remaining_summary(session)}]")
+        human = f"\u2716 {tid(idx)} dropped: \"{title}\". [{remaining_summary(session)}]"
+        emit_mutation("reckon:drop", session, affected=[(idx, dropped_snapshot)],
+                      config=load_config(), human_line=human)
 
     elif choice in ("t", "timebox"):
         target = args.date
@@ -1134,7 +1436,9 @@ def cmd_reckon(args):
             session["current_task_index"] = None
         save_session(session)
         render()
-        print(f"\u21b7 {tid(idx)} deferred for decomposition. [{remaining_summary(session)}]")
+        human = f"\u21b7 {tid(idx)} deferred for decomposition. [{remaining_summary(session)}]"
+        emit_mutation("reckon:break", session, affected=[(idx, task)],
+                      config=load_config(), human_line=human)
 
     elif choice in ("d", "delegate"):
         was_current = (idx == session.get("current_task_index"))
@@ -1146,7 +1450,9 @@ def cmd_reckon(args):
         task["notes"] = f"{existing}{sep}Reckoning: delegate/reassign.".strip()
         save_session(session)
         render()
-        print(f"\u21b7 {tid(idx)} deferred (delegate/reassign). [{remaining_summary(session)}]")
+        human = f"\u21b7 {tid(idx)} deferred (delegate/reassign). [{remaining_summary(session)}]"
+        emit_mutation("reckon:delegate", session, affected=[(idx, task)],
+                      config=load_config(), human_line=human)
 
     else:
         fail(f"Unknown reckoning choice: {choice}. Use b/d/x/t/k.")
@@ -1155,7 +1461,11 @@ def cmd_reckon(args):
 def cmd_status(args):
     session = load_session()
     config = load_config()
-    print(status_line(session, config))
+    if OUTPUT_FORMAT == "json":
+        print(json.dumps(_status_payload(session, config)))
+    else:
+        print(status_line(session, config))
+        print_task_list(session, config)
 
 
 def cmd_undo(args):
@@ -1181,7 +1491,17 @@ def cmd_undo(args):
 
     # Remove the consumed entry
     paths.UNDO_LOG.write_text("\n".join(lines[:-1]) + "\n" if lines[:-1] else "")
-    print(f"\u21a9 Undone ({target_str}). Restored state from {last['ts'][:19]}.")
+    human = f"\u21a9 Undone ({target_str}). Restored state from {last['ts'][:19]}."
+    # Re-read current state for full-list feedback (session may or may not have
+    # been the thing restored — either way we emit the current session view).
+    try:
+        _session = load_session()
+        emit_mutation("undo", _session, affected=[], config=load_config(), human_line=human)
+    except SystemExit:
+        if OUTPUT_FORMAT == "json":
+            print(json.dumps({"result": "ok", "action": "undo", "target": target_str}))
+        else:
+            print(human)
 
 
 def cmd_history(args):
@@ -1471,9 +1791,26 @@ def build_parser():
         prog="transition.py",
         description="workplanner task state transitions.",
     )
+    parser.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format. 'text' (default) is glyph-friendly, LLM- and human-readable. "
+             "'json' emits a structured response suitable for programmatic parsing.",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
-    sub.add_parser("done", help="Mark current task done.")
+    p_done = sub.add_parser("done", help="Mark current task done.")
+    p_done.add_argument(
+        "--as",
+        dest="as_title",
+        type=str,
+        default=None,
+        help="Echo the current task's title. If provided, the CLI refuses the mutation "
+             "unless the echoed title matches the target task's title "
+             "(case-insensitive, whitespace-tolerant).",
+    )
 
     p_blocked = sub.add_parser("blocked", help="Mark current task blocked.")
     p_blocked.add_argument("reason", nargs="*", help="Blocking reason (optional).")
@@ -1496,6 +1833,15 @@ def build_parser():
 
     p_remove = sub.add_parser("remove", help="Remove a task entirely.")
     p_remove.add_argument("target", help="Task ID (t3) or 0-based index (2).")
+    p_remove.add_argument(
+        "--as",
+        dest="as_title",
+        type=str,
+        default=None,
+        help="Echo the target task's title. If provided, the CLI refuses the mutation "
+             "unless the echoed title matches the target task's title "
+             "(case-insensitive, whitespace-tolerant).",
+    )
 
     p_move = sub.add_parser("move", help="Reorder a task.")
     p_move.add_argument("source", help="Task to move (t3 or 0-based index).")
@@ -1695,6 +2041,10 @@ def main():
     ensure_wrapper()
     parser = build_parser()
     args = parser.parse_args()
+    # Set module-level output format for this invocation so commands can
+    # branch on it (text vs json) without threading it through every call.
+    global OUTPUT_FORMAT
+    OUTPUT_FORMAT = getattr(args, "output_format", "text") or "text"
     handler = DISPATCH.get(args.command)
     if handler:
         handler(args)

--- a/docs/task-transitions.md
+++ b/docs/task-transitions.md
@@ -26,14 +26,25 @@ The `wpl` wrapper lives at `~/.workplanner/bin/wpl` and forwards to `bin/transit
 
 | Command | Args | Effect |
 |---------|------|--------|
-| `done` | — | Mark current task done (records actual_min), advance to next pending |
+| `done` | `[--as "<title>"]` | Mark current task done (records actual_min), advance to next pending |
 | `blocked` | `[reason...]` | Mark current task blocked, advance to next pending |
 | `defer` | — | Mark current task deferred, advance to next pending |
 | `add` | `<title> [flags]` | Add a new task (see flags below) |
 | `move` | `<source> --to <dest>` | Reorder a task to a new position |
 | `switch` | `<target> [--no-pause]` | Switch focus to a different task |
 | `dispatch` | `<target>` | Mark a task as dispatched to another session |
-| `status` | — | Print one-line status summary |
+| `remove` | `<target> [--as "<title>"]` | Remove a task entirely |
+| `status` | — | Print one-line status summary and full compact task list |
+
+### Global flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--format {text,json}` | `text` | Output format. Text is glyph-friendly and LLM- and human-readable. JSON emits a structured response suitable for programmatic parsing by skills that want machine-parsable output. |
+
+### `--as "<title>"` echo check
+
+`done` and `remove` accept an optional `--as "<title>"` argument. When present, the CLI compares the echoed title to the target task's actual title (case-insensitive, whitespace-tolerant). On mismatch, the mutation is refused with an error naming the actual title and UID, and the process exits non-zero. This is a cheap sanity check that catches "wrong-task" mistakes from stale display IDs, and self-documents the LLM's intent in the session transcript. Absent `--as`, behavior is unchanged.
 
 ### `add` flags
 
@@ -55,9 +66,15 @@ All mutating commands:
 3. Apply mutation
 4. Atomic write (tmp file → mv)
 5. Re-render dashboard via `render_dashboard.py`
-6. Print one-line confirmation to stdout
+6. Print one-line confirmation *plus the full compact task list* to stdout (text mode), or a structured JSON response (JSON mode)
 
 Exit code 0 on success, 1 on precondition failure (error to stderr).
+
+### Post-mutation feedback loop
+
+Every mutating command emits the full compact task list after its one-line confirmation. This keeps the LLM's model of session state synchronized with engine state across turn boundaries — without the LLM having to call `wpl status` between every mutation. The list includes UIDs (stable across mutations) alongside display IDs (`tN`, unstable; recomputed on every mutation). When addressing tasks, prefer UIDs.
+
+A `PostToolUse` plugin hook (`bin/post-tool-use-hook.sh`) provides a secondary feedback channel: after any Bash call whose command starts with `wpl`, the hook injects a compact session-state summary into the next turn's context. Both channels reinforce each other; neither is redundant.
 
 ## Transition Effects
 


### PR DESCRIPTION
## Summary

Stream A of the workplanner comprehensive pass. Subsumes issues #6 (task-ID
misidentification) and #9 (full-task-list view). Both are symptoms of a
missing post-mutation feedback loop plus a load-bearing identity-model choice
that the CLI never surfaced to its LLM-facing output.

- **Primary feedback channel**: every mutating `wpl` command now prints the
  full compact task list after the one-line confirmation. UIDs are included
  alongside display IDs. Shared `format_task_list()` keeps the layout in one
  place so no `cmd_*` duplicates it.
- **Identity**: UIDs (stable 8-char hex) are now first-class in default
  output, placed next to the unstable `tN`. LLMs can address tasks by UID
  across any mutation.
- **`--as "<title>"` echo arg** on `done` and `remove`: refuses the
  mutation if the echoed title doesn't match (case-insensitive,
  whitespace-tolerant). Cheap sanity check, self-documenting in the
  transcript.
- **`--format {text,json}`** top-level flag. Text (default) is glyph-friendly
  and LLM- and human-readable. JSON emits `{result, action, affected,
  session}` on mutations and a full status payload on `wpl status`. Errors
  emit JSON to stderr in JSON mode.
- **`PostToolUse` plugin hook** at `bin/post-tool-use-hook.sh`: after any
  Bash call whose command invokes `wpl`, injects a compact session-state
  summary (~500 token budget) into the next turn's context. Defense-in-depth
  for cross-turn drift.

Precondition resolutions encoded here:
- Q1 — UID-first for LLM, display-first for human.
- Q2 — defense in depth: stdout primary + PostToolUse secondary.
- Q3 — LLM retains authority; `--as` on destructive commands only.
- Q8 — dual format, LLM-first design, `--format json` opt-in.

## Files changed

- `bin/transition.py` — shared formatter, `emit_mutation`, `emit_error`,
  `OUTPUT_FORMAT` module-level flag, `--format` top-level arg, `--as` on
  done/remove, full-list emission on every mutating command, `WPL_ROOT` env
  var for test harnesses.
- `bin/render_dashboard.py` — honor `WPL_ROOT` env var (for tests only).
- `bin/post-tool-use-hook.sh` — new hook script.
- `.claude-plugin/plugin.json` — register the PostToolUse hook.
- `docs/task-transitions.md` — document `--as`, `--format json`, and the
  new feedback-loop behaviour.

## Test plan

Reproduced today's failure path against a temp profile:

1. `wpl backlog --from t5` — output includes the full compact renumbered
   list with UIDs. ✓
2. `wpl move t8 --to t4` — fails loudly with `Index 7 out of range` rather
   than silently acting on the wrong task. ✓
3. `wpl move b8888888 --to t4` — UID-based addressing works against the
   renumbered list. ✓
4. `wpl done --as "Wrong Title"` — refuses, names the actual title and
   UID. ✓
5. `wpl done --as "Review Stéphane's PR"` — case-insensitive and
   whitespace-tolerant match succeeds. ✓
6. `wpl status --format json` — valid JSON payload. ✓
7. PostToolUse hook on simulated Bash input with `wpl status` command —
   emits the documented `hookSpecificOutput` envelope with an
   additionalContext summary under 600 bytes. ✓
8. Hook no-ops on non-Bash tools and non-wpl Bash commands. ✓

Refs: #6, #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)