### PR TITLE
Stream B: local handoff doc + defer_reason (issues #3, #4)

### DIFF
--- a/bin/handoff.py
+++ b/bin/handoff.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Local-handoff doc read/write for workplanner.
+
+Writes per-day markdown handoff files under
+    ~/.workplanner/profiles/<resolved-profile-name>/handoffs/YYYY-MM-DD.md
+
+The file is split into named sections. Each section is further sub-divided
+by *session identifier* so concurrent sessions (e.g. dispatched tmux panes,
+multiple Claude instances) can each contribute without clobbering the others.
+
+On write, only the invoking session's own sub-sections are rewritten; other
+sessions' contributions are preserved verbatim. On read, sections are
+aggregated across all session sub-sections.
+
+CLI surface (used by skills):
+
+    # Write / update today's handoff for this session
+    python3 handoff.py write \
+        --session-id s-xxx \
+        --trajectory "bulleted markdown..." \
+        --deferred-json '[{"title":"...","uid":"...","reason":"..."}]' \
+        --open-questions "..." \
+        --context "..."
+
+    # Read today's handoff (or any specific date), print a JSON blob
+    python3 handoff.py read [--date YYYY-MM-DD]
+
+    # Print the path for today's handoff (doesn't create it)
+    python3 handoff.py path [--date YYYY-MM-DD]
+
+The `write` command is idempotent within a session-id: re-running it
+overwrites that session's sub-sections and leaves other sessions alone.
+
+Python 3.9+ stdlib only.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+from datetime import date as _date, datetime
+from pathlib import Path
+
+# Import minimally from transition.py (same dir) so we share profile
+# resolution and timezone logic. Avoid importing anything that mutates state.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from transition import (  # noqa: E402
+    resolve_paths,
+    load_config,
+    local_today,
+)
+
+
+# Ordered list of handoff sections. Writers update only these top-level
+# headings; anything outside the recognised set is preserved verbatim
+# (a human-authored free-text block, for instance, stays untouched).
+SECTIONS = [
+    "Session trajectory",
+    "Deferred with reasons",
+    "Open questions",
+    "Context for tomorrow",
+]
+
+
+# ── Session identifier ──────────────────────────────────────────────
+
+
+def session_id():
+    """Pick a stable-ish identifier for this *invocation's* session.
+
+    Priority:
+      1. $CLAUDE_SESSION_ID if set (Claude Code exposes this in some
+         contexts; workplanner treats it as authoritative when present).
+      2. $TMUX_PANE if running inside tmux (stable for the life of the pane).
+      3. Hash of python process start time (fallback; will not match across
+         re-invocations but prevents collisions with other sessions).
+
+    The ID is for disambiguation only. If it's not stable across
+    re-invocations, we accept some duplication over data loss.
+    """
+    claude = os.environ.get("CLAUDE_SESSION_ID", "").strip()
+    if claude:
+        # Truncate so section headers stay scannable.
+        return f"claude-{claude[:12]}"
+    pane = os.environ.get("TMUX_PANE", "").strip()
+    if pane:
+        # %0, %1, etc. — strip the leading % so the heading reads cleanly.
+        return f"pane-{pane.lstrip('%')}"
+    # Fallback: hash the start time. Stable across the life of this process.
+    try:
+        boot = str(time.time()).encode()
+        h = hashlib.sha1(boot).hexdigest()[:8]
+        return f"proc-{h}"
+    except Exception:
+        return "proc-unknown"
+
+
+# ── Path resolution ─────────────────────────────────────────────────
+
+
+def handoff_path_for(target_date=None):
+    """Return the path to the handoff file for the given date (default today).
+
+    Uses the *resolved* profile name, never the `active` alias in the path.
+    """
+    paths = resolve_paths()
+    if target_date is None:
+        target_date = local_today(load_config())
+    if isinstance(target_date, (datetime, _date)):
+        date_str = target_date.isoformat()[:10]
+    else:
+        date_str = str(target_date)
+    return paths.HANDOFFS / f"{date_str}.md"
+
+
+# ── Parsing ─────────────────────────────────────────────────────────
+
+
+SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+SUBSECTION_RE = re.compile(r"^###\s+(.+?)\s*$", re.MULTILINE)
+
+
+def _parse_sections(text):
+    """Parse the handoff markdown into a dict: section name → raw body.
+
+    Returns (ordered_keys, body_map, preamble). The preamble is whatever
+    appears before the first `## ` heading (typically the `# Handoff — DATE`
+    line). Unknown sections are retained; only known sections are updated on
+    write.
+    """
+    if not text:
+        return [], {}, ""
+    # Find all `## Heading` positions
+    matches = list(SECTION_RE.finditer(text))
+    if not matches:
+        return [], {}, text
+    preamble = text[: matches[0].start()]
+    ordered = []
+    body = {}
+    for i, m in enumerate(matches):
+        name = m.group(1).strip()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        ordered.append(name)
+        body[name] = text[start:end]
+    return ordered, body, preamble
+
+
+def _parse_subsections(section_body):
+    """Parse a section body into {session-id-heading: raw_body}.
+
+    Returns (ordered_ids, body_map, preamble). Preamble is any content
+    between the section heading and the first `###` sub-heading (usually
+    empty or a short note).
+    """
+    matches = list(SUBSECTION_RE.finditer(section_body))
+    if not matches:
+        return [], {}, section_body
+    preamble = section_body[: matches[0].start()]
+    ordered = []
+    body = {}
+    for i, m in enumerate(matches):
+        sid = m.group(1).strip()
+        start = m.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(section_body)
+        ordered.append(sid)
+        body[sid] = section_body[start:end]
+    return ordered, body, preamble
+
+
+# ── Reading ─────────────────────────────────────────────────────────
+
+
+def read_handoff(target_date=None):
+    """Read a handoff file (default today). Return a dict suitable for skills.
+
+    Shape:
+        {
+          "path": "/abs/path/YYYY-MM-DD.md",
+          "date": "YYYY-MM-DD",
+          "exists": True/False,
+          "sections": {
+            "Session trajectory": {
+              "<session-id>": "raw markdown body",
+              ...
+            },
+            ...
+          },
+          "raw": "...",          # the full file, for fallback
+          "deferred": [          # best-effort parse of "Deferred with reasons"
+            {"title": "...", "uid": "...", "reason": "...", "session": "..."},
+            ...
+          ]
+        }
+    """
+    path = handoff_path_for(target_date)
+    out = {
+        "path": str(path),
+        "date": path.stem,
+        "exists": path.exists(),
+        "sections": {name: {} for name in SECTIONS},
+        "raw": "",
+        "deferred": [],
+    }
+    if not path.exists():
+        return out
+    text = path.read_text()
+    out["raw"] = text
+    _, bodies, _ = _parse_sections(text)
+    for name in SECTIONS:
+        if name not in bodies:
+            continue
+        _, subs, _ = _parse_subsections(bodies[name])
+        for sid, body in subs.items():
+            out["sections"][name][sid] = body.rstrip() + "\n"
+
+    # Best-effort extraction of deferred items. Pattern per-line:
+    #   - **<title>** (<uid>): <reason>
+    # Everything else is returned as raw text under sections → skills can
+    # still display it as-is if the line doesn't match.
+    deferred_section = out["sections"].get("Deferred with reasons", {})
+    line_re = re.compile(r"^\s*-\s+\*\*(?P<title>[^*]+)\*\*\s*(?:\(([^)]+)\))?\s*:\s*(?P<reason>.+?)\s*$")
+    for sid, body in deferred_section.items():
+        for line in body.splitlines():
+            m = line_re.match(line)
+            if m:
+                out["deferred"].append({
+                    "title": m.group("title").strip(),
+                    "uid": (m.group(2) or "").strip(),
+                    "reason": m.group("reason").strip(),
+                    "session": sid,
+                })
+    return out
+
+
+# ── Writing ─────────────────────────────────────────────────────────
+
+
+def _render_session_sub(session_id_str, body):
+    """Render a single session's sub-section body under a `### <sid>` heading."""
+    body = (body or "").strip()
+    if not body:
+        return ""
+    return f"### {session_id_str}\n\n{body}\n\n"
+
+
+def _render_deferred_body(deferred_items):
+    """Turn a list of {title, uid, reason} dicts into the canonical markdown form.
+
+    The parser in read_handoff() pairs with this format — keep them in sync.
+    """
+    if not deferred_items:
+        return ""
+    lines = []
+    for item in deferred_items:
+        title = (item.get("title") or "").strip() or "(untitled)"
+        uid = (item.get("uid") or "").strip()
+        reason = (item.get("reason") or "").strip() or "(no reason given)"
+        uid_tag = f" ({uid})" if uid else ""
+        lines.append(f"- **{title}**{uid_tag}: {reason}")
+    return "\n".join(lines)
+
+
+def write_handoff(
+    session_id_str,
+    trajectory=None,
+    deferred=None,
+    open_questions=None,
+    context=None,
+    target_date=None,
+):
+    """Merge-by-section write for today's handoff.
+
+    Only this session's `### <session_id>` sub-sections are rewritten.
+    Other sessions' sub-sections are preserved verbatim. Unknown top-level
+    sections (outside SECTIONS) are also preserved — a human could drop a
+    free-text note at the end and it would survive future EOD writes.
+
+    Any of trajectory / deferred / open_questions / context that are None
+    or empty are treated as "this session has no contribution to that
+    section this invocation" — the session's existing sub-section (if any)
+    is removed. If the whole section would become empty across all sessions,
+    the section is dropped entirely.
+
+    `deferred` may be a list of {title, uid, reason} dicts OR a
+    pre-rendered markdown string. Dicts get rendered via
+    _render_deferred_body().
+    """
+    path = handoff_path_for(target_date)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing_text = path.read_text() if path.exists() else ""
+    ordered, bodies, preamble = _parse_sections(existing_text)
+
+    # If file is new, build an initial preamble.
+    if not preamble and not ordered:
+        date_str = path.stem
+        preamble = f"# Handoff — {date_str}\n\n"
+
+    # Build the new contributions for this session.
+    new_contributions = {
+        "Session trajectory": _normalise_body(trajectory),
+        "Deferred with reasons": (
+            _render_deferred_body(deferred)
+            if isinstance(deferred, list) else _normalise_body(deferred)
+        ),
+        "Open questions": _normalise_body(open_questions),
+        "Context for tomorrow": _normalise_body(context),
+    }
+
+    # For each known section, splice this session's sub-section in/out.
+    # Unknown sections (not in SECTIONS) pass through unchanged.
+    updated_ordered = list(ordered)  # preserve existing section order + unknowns
+    updated_bodies = dict(bodies)
+
+    for section_name in SECTIONS:
+        sub_ids, subs, sub_preamble = _parse_subsections(bodies.get(section_name, ""))
+        new_body = new_contributions[section_name]
+        if new_body:
+            subs[session_id_str] = new_body
+            if session_id_str not in sub_ids:
+                sub_ids.append(session_id_str)
+        else:
+            # This session has nothing to say → drop its entry.
+            subs.pop(session_id_str, None)
+            sub_ids = [s for s in sub_ids if s != session_id_str]
+
+        if not subs:
+            # Section now empty; drop it from the file.
+            if section_name in updated_bodies:
+                del updated_bodies[section_name]
+                updated_ordered = [s for s in updated_ordered if s != section_name]
+            continue
+
+        # Re-render the section body preserving sub-id order.
+        parts = []
+        for sid in sub_ids:
+            parts.append(_render_session_sub(sid, subs[sid]))
+        section_text = (sub_preamble.strip() + "\n\n" if sub_preamble.strip() else "") + "".join(parts)
+        updated_bodies[section_name] = "\n" + section_text  # leading newline after the `## Heading`
+        if section_name not in updated_ordered:
+            updated_ordered.append(section_name)
+
+    # Reorder: put known sections first in canonical order, then any unknowns
+    # (anything the writer didn't touch) in their original relative order.
+    known_in_file = [s for s in SECTIONS if s in updated_ordered]
+    unknown = [s for s in updated_ordered if s not in SECTIONS]
+    final_order = known_in_file + unknown
+
+    # Rebuild the full text.
+    out = preamble.rstrip() + "\n\n" if preamble.strip() else ""
+    for name in final_order:
+        body = updated_bodies.get(name, "").rstrip()
+        out += f"## {name}\n{body}\n\n"
+
+    # Atomic write.
+    target = path.resolve() if path.exists() else path
+    tmp = str(target) + ".tmp"
+    with open(tmp, "w") as f:
+        f.write(out.rstrip() + "\n")
+    os.rename(tmp, str(target))
+    return path
+
+
+def _normalise_body(body):
+    """Normalise the body to a trimmed string, or empty if None/whitespace."""
+    if body is None:
+        return ""
+    if isinstance(body, str):
+        return body.strip()
+    # List of lines? Join them.
+    if isinstance(body, list):
+        return "\n".join(str(x) for x in body).strip()
+    return str(body).strip()
+
+
+# ── CLI ─────────────────────────────────────────────────────────────
+
+
+def _cmd_write(args):
+    deferred = None
+    if args.deferred_json:
+        try:
+            deferred = json.loads(args.deferred_json)
+        except json.JSONDecodeError as e:
+            print(f"error: --deferred-json is not valid JSON: {e}", file=sys.stderr)
+            sys.exit(1)
+    elif args.deferred:
+        deferred = args.deferred
+
+    sid = args.session_id or session_id()
+    path = write_handoff(
+        session_id_str=sid,
+        trajectory=args.trajectory,
+        deferred=deferred,
+        open_questions=args.open_questions,
+        context=args.context,
+        target_date=args.date,
+    )
+    print(str(path))
+
+
+def _cmd_read(args):
+    data = read_handoff(target_date=args.date)
+    print(json.dumps(data, indent=2))
+
+
+def _cmd_path(args):
+    print(str(handoff_path_for(args.date)))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="handoff.py",
+        description="workplanner local handoff doc read/write.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    w = sub.add_parser("write", help="Write or update today's handoff for a session.")
+    w.add_argument("--session-id", default=None, help="Session ID sub-heading; auto-detected if absent.")
+    w.add_argument("--trajectory", default=None, help="Session trajectory markdown body.")
+    w.add_argument("--deferred", default=None, help="Deferred-with-reasons markdown body (or use --deferred-json).")
+    w.add_argument("--deferred-json", default=None, help="JSON list of {title, uid, reason} dicts.")
+    w.add_argument("--open-questions", default=None, help="Open questions markdown body.")
+    w.add_argument("--context", default=None, help="Context-for-tomorrow markdown body.")
+    w.add_argument("--date", default=None, help="ISO date (YYYY-MM-DD). Default: today in profile timezone.")
+    w.set_defaults(func=_cmd_write)
+
+    r = sub.add_parser("read", help="Read a handoff file and print JSON.")
+    r.add_argument("--date", default=None, help="ISO date (default: today).")
+    r.set_defaults(func=_cmd_read)
+
+    p = sub.add_parser("path", help="Print the path of the handoff file.")
+    p.add_argument("--date", default=None, help="ISO date (default: today).")
+    p.set_defaults(func=_cmd_path)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -740,18 +740,28 @@ def cmd_defer(args):
     if task["status"] not in ("in_progress", "pending"):
         fail(f"{tid(idx)} is {task['status']}, can't defer.")
 
+    reason = getattr(args, "reason", None)
+    prior_reason = task.get("defer_reason")
+
     until = getattr(args, "until", None)
     if until:
         # Defer to backlog with target_date
         target_date = parse_relative_date(until)
         if target_date is None:
             fail(f"Can't parse date: {until}. Use YYYY-MM-DD, tomorrow, monday-sunday, or next-week.")
+        # Attach reason before moving so it travels into the backlog item.
+        if reason:
+            task["defer_reason"] = reason
         _move_task_to_backlog(session, idx, target_date=target_date.isoformat())
         return
 
     # Track deferral count
     count = task.get("deferral_count", 0) + 1
     task["deferral_count"] = count
+
+    # Attach/refresh the reason if one was provided on this invocation.
+    if reason:
+        task["defer_reason"] = reason
 
     # Check reckoning threshold
     config = load_config()
@@ -760,13 +770,18 @@ def cmd_defer(args):
                  .get("reckoning_threshold", 3))
     if count >= threshold:
         print(f"\u26a0 {tid(idx)} \"{task['title']}\" has been deferred {count} times.")
+        # Surface prior context so the reckoning decision has the "why" in hand.
+        if reason:
+            print(f"  Reason (this defer): {reason}")
+        elif prior_reason:
+            print(f"  Last reason: {prior_reason}")
         print(f"  What's actually going on?")
         print(f"  [b] Break it down into smaller tasks")
         print(f"  [d] Delegate \u2014 reassign or ask for help")
         print(f"  [x] Drop it \u2014 it's not going to happen")
         print(f"  [t] Timebox \u2014 schedule a dedicated block (sends to backlog with target date)")
         print(f"  [k] Keep deferring \u2014 I'll get to it")
-        # Save the incremented count but don't change status yet
+        # Save the incremented count (and reason, if given) but don't change status yet.
         save_session(session, undo=False)
         sys.exit(2)  # Signal to calling skill that reckoning is needed
 
@@ -779,7 +794,8 @@ def cmd_defer(args):
     save_session(session)
     render()
 
-    human = f"\u21b7 {tid(idx)} deferred ({count}x). [{remaining_summary(session)}]"
+    reason_tag = f" \u2014 {task['defer_reason']}" if task.get("defer_reason") else ""
+    human = f"\u21b7 {tid(idx)} deferred ({count}x){reason_tag}. [{remaining_summary(session)}]"
     emit_mutation("defer", session, affected=[(idx, task)],
                   config=load_config(), human_line=human)
 
@@ -1036,6 +1052,12 @@ def _move_task_to_backlog(session, idx, target_date=None, not_before=None, deadl
         "deadline": deadline,
         "tags": tags or [],
     }
+    # Preserve defer_reason if it was recorded on the task (so carryover keeps context).
+    if task.get("defer_reason"):
+        item["defer_reason"] = task["defer_reason"]
+    # Preserve deferral_count so history-scoped reckoning can reason about it later.
+    if task.get("deferral_count"):
+        item["deferral_count"] = task["deferral_count"]
     backlog["items"].append(item)
 
     # Remove from session
@@ -1268,6 +1290,12 @@ def _backlog_promote(args):
         new_task["url"] = item["url"]
     if item.get("notes"):
         new_task["notes"] = item["notes"]
+    # Carry defer_reason / deferral_count back into the session task so the "why"
+    # travels with the task across the backlog round-trip.
+    if item.get("defer_reason"):
+        new_task["defer_reason"] = item["defer_reason"]
+    if item.get("deferral_count"):
+        new_task["deferral_count"] = item["deferral_count"]
 
     tasks = session.get("tasks", [])
     cur_idx = session.get("current_task_index")
@@ -1388,6 +1416,14 @@ def cmd_reckon(args):
     if task is None:
         fail("No current task.")
 
+    # If the user passed a --reason, attach/update it now so it surfaces in the
+    # post-reckon output line and travels with the task (whether it stays in
+    # session, is dropped, or is moved to the backlog).
+    new_reason = getattr(args, "reason", None)
+    if new_reason:
+        task["defer_reason"] = new_reason
+    prior_reason = task.get("defer_reason")
+
     choice = args.choice.lower()
     if choice in ("k", "keep"):
         # Force defer despite threshold
@@ -1398,7 +1434,8 @@ def cmd_reckon(args):
         save_session(session)
         render()
         count = task.get("deferral_count", 0)
-        human = f"\u21b7 {tid(idx)} deferred ({count}x, keeping). [{remaining_summary(session)}]"
+        reason_tag = f" \u2014 {prior_reason}" if prior_reason else ""
+        human = f"\u21b7 {tid(idx)} deferred ({count}x, keeping){reason_tag}. [{remaining_summary(session)}]"
         emit_mutation("reckon:keep", session, affected=[(idx, task)],
                       config=load_config(), human_line=human)
 
@@ -1436,7 +1473,8 @@ def cmd_reckon(args):
             session["current_task_index"] = None
         save_session(session)
         render()
-        human = f"\u21b7 {tid(idx)} deferred for decomposition. [{remaining_summary(session)}]"
+        reason_tag = f" \u2014 {prior_reason}" if prior_reason else ""
+        human = f"\u21b7 {tid(idx)} deferred for decomposition{reason_tag}. [{remaining_summary(session)}]"
         emit_mutation("reckon:break", session, affected=[(idx, task)],
                       config=load_config(), human_line=human)
 
@@ -1450,7 +1488,8 @@ def cmd_reckon(args):
         task["notes"] = f"{existing}{sep}Reckoning: delegate/reassign.".strip()
         save_session(session)
         render()
-        human = f"\u21b7 {tid(idx)} deferred (delegate/reassign). [{remaining_summary(session)}]"
+        reason_tag = f" \u2014 {prior_reason}" if prior_reason else ""
+        human = f"\u21b7 {tid(idx)} deferred (delegate/reassign){reason_tag}. [{remaining_summary(session)}]"
         emit_mutation("reckon:delegate", session, affected=[(idx, task)],
                       config=load_config(), human_line=human)
 
@@ -1817,6 +1856,7 @@ def build_parser():
 
     p_defer = sub.add_parser("defer", help="Defer current task.")
     p_defer.add_argument("--until", type=str, default=None, help="Target date (YYYY-MM-DD, tomorrow, monday, next-week). Sends to backlog.")
+    p_defer.add_argument("--reason", type=str, default=None, help="Why the task is being deferred. Persists on the task and surfaces in reckoning and handoff.")
 
     p_add = sub.add_parser("add", help="Add a new task.")
     p_add.add_argument("title", nargs="+", help="Task title.")
@@ -1874,6 +1914,7 @@ def build_parser():
     p_reckon = sub.add_parser("reckon", help="Apply a reckoning decision after deferral threshold.")
     p_reckon.add_argument("choice", help="Decision: b(reak), d(elegate), x/drop, t(imebox), k(eep).")
     p_reckon.add_argument("--date", type=str, default=None, help="Target date for timebox (required for 't').")
+    p_reckon.add_argument("--reason", type=str, default=None, help="Update the defer_reason alongside the reckoning decision.")
 
     sub.add_parser("status", help="Print one-line status.")
 

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -46,6 +46,7 @@ def resolve_paths():
     root = resolve_profile_root()
     class P:
         PROFILE_ROOT = root
+        PROFILE_NAME = root.name  # concrete name, not the 'active' alias
         SESSION = root / "session" / "current-session.json"
         CONFIG = root / "config.json"
         BACKLOG = root / "backlog.json"
@@ -55,6 +56,10 @@ def resolve_paths():
         EVENTS = root / "session" / "events.json"
         AGENDAS = root / "session" / "agendas"
         BRIEFINGS = root / "briefings"
+        # Session-handoff docs (local narrative) live under the *concrete*
+        # profile-name path, never under profiles/active/. This sidesteps the
+        # known profile-symlink race (issue #10) for this artifact.
+        HANDOFFS = root / "handoffs"
     return P
 
 

--- a/docs/eod-consolidation.md
+++ b/docs/eod-consolidation.md
@@ -1,21 +1,21 @@
 # EOD Consolidation Procedure
 
-Internal reference for the end-of-day consolidation pipeline. Wraps up the session, posts updates, and prepares carryover for the next day.
+Internal reference for the end-of-day consolidation pipeline. Wraps up the session, posts updates, writes the local handoff doc, and prepares carryover for the next day.
 
 ---
 
 ## Overview
 
-Four sequential steps. Unlike morning assembly, these are not checkpointed -- they run in order each time EOD is triggered.
+Five sequential steps. Unlike morning assembly, these are not checkpointed -- they run in order each time EOD is triggered.
 
 ---
 
 ## Step 1: Finalize Tasks
 
 1. Check for any tasks with status `in_progress` or `pending`.
-2. Present them to the user and ask once: "done, defer, or blocked?"
-3. The user can answer for all at once (e.g., "t3 done, t4 defer").
-4. Update all statuses accordingly in `current-session.json`.
+2. Present them to the user and ask once: "done, defer (with reason?), or blocked?"
+3. The user can answer for all at once (e.g., "t3 done, t4 defer — waiting on legal").
+4. Update all statuses accordingly in `current-session.json`. Deferred tasks should carry a `defer_reason` where the user provided one — `wpl defer --reason "..."` sets this field on the task, and it persists across carryover.
 
 ---
 
@@ -49,8 +49,17 @@ Four sequential steps. Unlike morning assembly, these are not checkpointed -- th
 
 ---
 
-## Step 4: Carryover
+## Step 4: Local Handoff Doc
+
+1. Write (or update) today's handoff file at `~/.workplanner/profiles/<resolved-profile-name>/handoffs/YYYY-MM-DD.md` using `bin/handoff.py write`.
+2. The file uses a merge-by-section format so concurrent sessions (dispatched tmux panes, multiple Claude instances) each contribute to their own `### <session-id>` sub-section without clobbering others.
+3. Sections written: `Session trajectory`, `Deferred with reasons` (each deferred/blocked task with its `defer_reason`), `Open questions`, `Context for tomorrow`.
+4. Session identifier is auto-detected: `$CLAUDE_SESSION_ID` → `$TMUX_PANE` → process-start-hash fallback.
+5. Idempotent within a session: re-running EOD overwrites this session's sub-sections only.
+6. On success, set `eod_handoff_written: true` in session state (a separate checkpoint from `eod_posted`, which tracks Linear posting).
+
+## Step 5: Carryover & Close
 
 1. Extract all tasks with status `deferred` or `blocked` from the session.
-2. Write the carryover record into session state for the next morning assembly.
-3. Close the session: set a final phase marker indicating the day is complete.
+2. Write the carryover record into session state for the next morning assembly. Tasks keep their `defer_reason` field intact.
+3. Close the session: set `checkpoint: "closed"`.

--- a/docs/morning-assembly.md
+++ b/docs/morning-assembly.md
@@ -36,6 +36,16 @@ Compute `sweep_since` from previous session:
 - If no previous session: use yesterday 08:00 in `config.timezone`
 - Store as `session.sweep_since` (ISO 8601)
 
+### Step 0.25: Read yesterday's handoff doc
+
+Before any inbox scanning, read yesterday's local handoff (`~/.workplanner/profiles/<name>/handoffs/YYYY-MM-DD.md`) via `bin/handoff.py read --date <yesterday>`. Aggregates across session sub-sections. Feeds into:
+
+- **Carryover mini-triage** in Step 3 (below) — each deferred task's `defer_reason` is surfaced inline so "does this still matter?" has context.
+- **Headlines** — "Open questions" from yesterday become session-start headlines.
+- **Pre-conditioning** — "Context for tomorrow" notes are read once before the day's planning.
+
+If the file is absent (fresh install, or yesterday's `/eod` skipped), log "No handoff for yesterday" and fall back to session-JSON carryover (status + deferral_count only, no reasons).
+
 ### Step 0.5: Pre-work activity scan
 
 Before the inbox sweep, check if the user already did work this morning (Slack replies, blog comments, etc.). Uses `config.triage.pre_work` settings. If activity exceeds `min_minutes_for_task` (default: 5), inserts a completed "Morning communication work" task at position 0. See `skills/start/SKILL.md` for full procedure.
@@ -85,9 +95,10 @@ Transform `session.inbox_items[]` into `session.tasks[]`.
 
 1. **Deduplicate** — Match by `dedupe_key` (Linear ref or normalized URL). Merge: keep highest priority, combine context
 2. **Triage & Prioritize** — Assign priority tiers, apply timebox estimates
-3. **Filter for Today** — Always include carryover/critical/high/overdue/due-today. Medium if budget allows. Cap at 10 tasks.
-4. **Order** — Carryover → Critical → High (due-today first) → Medium → Focus/check-in
-5. **Insert Time Structure** — Protected blocks + calendar events. Compute budget.
+3. **Carryover mini-triage** — For each carryover task, surface its `defer_reason` (from yesterday's handoff + task state) and ask "keep / defer / drop / backlog / re-scope?". Items at `deferral_count >= config.triage.deferrals.reckoning_threshold` escalate to the full reckoning prompt. Full details: `skills/start/SKILL.md` Step 3.
+4. **Filter for Today** — Always include carryover/critical/high/overdue/due-today. Medium if budget allows. Cap at 10 tasks.
+5. **Order** — Carryover → Critical → High (due-today first) → Medium → Focus/check-in
+6. **Insert Time Structure** — Protected blocks + calendar events. Compute budget.
 
 After triage, **clear `session.inbox_items[]`** to keep session JSON lean. The data has been consumed into `session.tasks[]` and `session.headlines[]`.
 

--- a/docs/state-schema.md
+++ b/docs/state-schema.md
@@ -88,6 +88,7 @@ Tasks do NOT have an `id` field in JSON. Display IDs (`t1`, `t2`, ...) are deriv
 | `notes` | `string \| null` | no | Free-text notes. |
 | `parent` | `integer \| null` | no | 0-based index of parent task for sub-task nesting. |
 | `deferral_count` | `integer` | no | Number of times this task has been deferred (persists through carryover). Default: 0. When this reaches `config.triage.deferrals.reckoning_threshold`, the system triggers a forced reckoning prompt instead of silently deferring. |
+| `defer_reason` | `string` | no | Optional human-readable explanation of *why* the task was deferred. Set via `wpl defer --reason "..."` (or `wpl reckon <choice> --reason "..."`). Persists on the task, travels across carryover (session → backlog → session), and is surfaced in reckoning prompts, `/eod` handoff doc, and `/start` carryover mini-triage. Absent on older state files — migration-safe (any consumer uses `.get()`). |
 
 ### State mutations
 
@@ -276,6 +277,8 @@ Uses the same base fields as a session task, plus temporal targeting fields.
 | `not_before` | `string` (ISO date) \| null | no | "Don't surface until this date." Suppresses auto-promotion. |
 | `deadline` | `string` (ISO date) \| null | no | Hard deadline. Drives urgency warnings and auto-promotion when ≤2 days away. |
 | `tags` | `array` of `string` | no | Lightweight categorization for filtering in `/horizon`. |
+| `defer_reason` | `string` | no | Preserved when a deferred session task is sent to the backlog; carried back to the promoted session task on `backlog --promote`. |
+| `deferral_count` | `integer` | no | Preserved alongside `defer_reason` so reckoning signal survives the backlog round-trip. |
 
 ### Surfacing rules
 

--- a/docs/state-schema.md
+++ b/docs/state-schema.md
@@ -25,8 +25,9 @@ Source of truth for all session state. If the JSON and any derived artifacts (ma
 | `current_task_index` | `integer \| null` | yes | 0-based index of the active task in the `tasks` array, or `null` if no task is active. |
 | `tasks` | `array` | yes | Ordered list of task objects. |
 | `coordination_thread` | `object \| null` | no | Captured Slack coordination thread, if any. |
-| `eod_posted` | `boolean` | yes | Whether the end-of-day summary has been posted. |
+| `eod_posted` | `boolean` | yes | Whether the end-of-day summary has been posted (to Linear / external system). |
 | `eod_linear_comment_url` | `string \| null` | yes | URL of the EOD comment on Linear, or `null` if not yet posted. |
+| `eod_handoff_written` | `boolean` | no | Whether this session wrote its contribution to today's local handoff doc (`profiles/<name>/handoffs/YYYY-MM-DD.md`). Distinct from `eod_posted` — handoff-write and Linear-post are separate checkpoints. Default: absent/`false` on older sessions (migration-safe). |
 | `sweep_since` | `string` (ISO 8601) \| null | no | Cutoff timestamp for inbox sweep. Computed from previous session's EOD or yesterday 08:00. |
 | `inbox_items` | `array` | no | Raw captured items from inbox sweep. Cleared after `agenda_built`. See inbox item schema. |
 | `headlines` | `array` of `string` | no | FYI items for agenda header (from digest + low-signal sources). |
@@ -188,6 +189,47 @@ Optional. Controls priority assignment, estimate defaults, ordering, and deferra
   "manual": 30, "focus": 30
 }
 ```
+
+---
+
+## Handoff docs
+
+**Location:** `~/.workplanner/profiles/<name>/handoffs/{YYYY-MM-DD}.md`
+
+Workspace-local markdown files written by `/eod` and read by the next day's `/start`. One file per date. The path uses the *concrete* profile name (not the `active` alias) so concurrent sessions don't race the symlink.
+
+### Structure
+
+Merge-by-section format. Top-level `## Heading` sections, each further split into `### <session-id>` sub-sections so concurrent sessions contribute without clobbering each other.
+
+Recognised sections (writers only touch these; anything else passes through verbatim):
+
+| Section | Purpose |
+|---------|---------|
+| `## Session trajectory` | High-level narrative of what got done, deferred, blocked. |
+| `## Deferred with reasons` | Every task ending the day `deferred` or `blocked`, with `defer_reason` inline. Format: `- **<title>** (<uid>): <reason>`. |
+| `## Open questions` | Things the LLM or user noticed that need decision/research/escalation. |
+| `## Context for tomorrow` | Short concrete pointers for the next morning. |
+
+### Session identifier
+
+`### <session-id>` sub-headings disambiguate concurrent writers. The identifier is picked by `bin/handoff.py` in priority order:
+
+1. `$CLAUDE_SESSION_ID` if set
+2. `$TMUX_PANE` if running inside tmux (e.g., `pane-%3`)
+3. Hash of the python process start time (fallback — stable within a process, not across re-invocations)
+
+### Read/write API
+
+The file is read and written through `bin/handoff.py`. Skills never edit it directly.
+
+```bash
+python3 bin/handoff.py write --trajectory "..." --deferred-json '[{...}]' --open-questions "..." --context "..."
+python3 bin/handoff.py read [--date YYYY-MM-DD]    # prints JSON with {path, date, exists, sections, deferred, raw}
+python3 bin/handoff.py path [--date YYYY-MM-DD]    # prints the resolved path
+```
+
+`write` is idempotent within a session-id: re-running overwrites that session's sub-sections only. Other sessions' sub-sections and unrecognised `## ...` sections (e.g., human free-text additions) are preserved verbatim.
 
 ---
 

--- a/skills/eod/SKILL.md
+++ b/skills/eod/SKILL.md
@@ -7,10 +7,11 @@ allowed-tools: Read, Write, Bash, AskUserQuestion, ToolSearch, mcp__linear-serve
 
 # EOD Consolidation
 
-End-of-day wrap-up. Four steps: finalize tasks, draft Linear update, draft Slack handoff, close session.
+End-of-day wrap-up. Five steps: finalize tasks, draft Linear update, draft Slack handoff, write the local handoff doc, close session.
 
 **Plugin root:** `${CLAUDE_PLUGIN_ROOT}`
 **Transition CLI:** `wpl` (or `${CLAUDE_PLUGIN_ROOT}/bin/transition.py` if wrapper not created yet)
+**Handoff library:** `${CLAUDE_PLUGIN_ROOT}/bin/handoff.py` (read / write / path subcommands)
 **Full procedure:** `${CLAUDE_PLUGIN_ROOT}/docs/eod-consolidation.md`
 
 ## Procedure
@@ -29,21 +30,23 @@ These tasks are still open:
 ○ t5 — Weekly check-in (pending)
 ```
 
-Ask once: "For each: done, defer, blocked, or backlog?"
+Ask once: "For each: done, defer (with reason?), blocked, or backlog?"
 
-Let the user answer for all at once (free text, e.g. "t2 done, t5 defer, t6 backlog friday"). Parse and apply each via transition CLI:
+When deferring, **prompt for a reason** — "waiting on legal", "underspecified", "blocked on infra", etc. A one-line reason is enough; the point is to carry the "why" into tomorrow's carryover surface so the same task doesn't silently re-appear with zero context.
+
+Let the user answer for all at once (free text, e.g. "t2 done, t5 defer — waiting on legal, t6 backlog friday"). Parse and apply each via transition CLI:
 
 ```bash
 wpl done
 wpl switch t5
-wpl defer
+wpl defer --reason "waiting on legal"
 wpl switch t6
 wpl backlog --from-current --target friday   # sends to backlog with target date
 ```
 
-**Backlog option:** When the user says "backlog" for a task, optionally with a date (e.g., "backlog friday", "backlog 2026-04-01"), move it to `~/.workplanner/profiles/active/backlog.json` instead of deferring. Use `--from-current` or `--from t{N}` with `--target` if a date is given. This is for work that doesn't belong on tomorrow's agenda but needs to surface later.
+**Backlog option:** When the user says "backlog" for a task, optionally with a date (e.g., "backlog friday", "backlog 2026-04-01"), move it to the backlog file instead of deferring. Use `--from-current` or `--from t{N}` with `--target` if a date is given. This is for work that doesn't belong on tomorrow's agenda but needs to surface later.
 
-**Deferral reckoning:** If `wpl defer` exits with code 2, the task has hit its deferral threshold (default: 3x). The CLI already printed the reckoning prompt. Read the user's choice and apply via `wpl reckon <choice> [--date <date>]`. Options: `b` (break down — defer, then help decompose), `d` (delegate), `x` (drop), `t` (timebox to backlog, requires `--date`), `k` (keep deferring).
+**Deferral reckoning:** If `wpl defer` exits with code 2, the task has hit its deferral threshold (default: 3x). The CLI already printed the reckoning prompt (and will surface any prior `defer_reason` inline). Read the user's choice and apply via `wpl reckon <choice> [--date <date>] [--reason "..."]`. Options: `b` (break down — defer, then help decompose), `d` (delegate), `x` (drop), `t` (timebox to backlog, requires `--date`), `k` (keep deferring).
 
 ### Step 2: Draft Linear update
 
@@ -77,10 +80,56 @@ Draft 2-3 sentences for the coordination channel (`config.coordination_channel`)
 
 Do NOT post to Slack.
 
-### Step 4: Close session
+### Step 4: Write local handoff doc
+
+Write (or update) the session's contribution to today's local handoff doc:
+
+```
+~/.workplanner/profiles/<resolved-profile-name>/handoffs/YYYY-MM-DD.md
+```
+
+Unlike the Linear/Slack drafts (which are one-shot posts to external systems), this is a **workspace-local, structured record** that tomorrow's `/start` will read during carryover mini-triage. Multiple sessions (dispatched tmux panes, multiple Claude instances) can each contribute; `handoff.py` merges by section and by session ID so writers never clobber each other.
+
+**Sections this session writes:**
+- **Session trajectory** — high-level narrative of what got done, deferred, blocked. Not a minute-by-minute log; a readable "here's where the day landed" paragraph or bulleted summary.
+- **Deferred with reasons** — every task that ended the day in `deferred` or `blocked` status, with the `defer_reason` (or blocked reason from `notes`) inline. This is the field tomorrow's mini-triage pivots on.
+- **Open questions** — anything the LLM (you) noticed during the day that needs a human decision, research, or escalation but wasn't captured elsewhere.
+- **Context for tomorrow** — short, concrete pointers. "Check the deploy in #release-room first thing," "the PR #1234 discussion hit a wall — re-read before replying."
+
+**Collecting the content:**
+
+1. Read final session state:
+   ```bash
+   SESSION_JSON=$(cat ~/.workplanner/profiles/active/session/current-session.json)
+   ```
+
+   (The skill runs after tasks are finalized, so `deferred`/`blocked` statuses are accurate.)
+
+2. Extract deferred/blocked tasks with their reasons. For each such task, build a dict:
+   ```json
+   {"title": "<task title>", "uid": "<task.uid>", "reason": "<task.defer_reason OR parsed from notes>"}
+   ```
+
+3. Pass everything to `handoff.py write`:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/bin/handoff.py" write \
+     --trajectory "$TRAJECTORY_MARKDOWN" \
+     --deferred-json "$DEFERRED_JSON" \
+     --open-questions "$OPEN_Q_MARKDOWN" \
+     --context "$CONTEXT_MARKDOWN"
+   ```
+
+   Omit any flag where this session has nothing to say — the library drops empty sub-sections automatically. Do NOT pass an explicit `--session-id`; the library picks one from `$CLAUDE_SESSION_ID` → `$TMUX_PANE` → process-start-hash fallback.
+
+**Idempotent within a session:** If `/eod` is re-run (e.g., after a fix-up), the write overwrites *this session's* sub-sections only. Other sessions' contributions are preserved.
+
+**Separate checkpoint from `eod_posted`:** writing the handoff is a distinct operation from posting to Linear. The session state records it as `eod_handoff_written: true` (extend `current-session.json` with this boolean — it's a new field, default absent/false for older sessions). This lets the stale-session handler distinguish "Linear post pending" from "handoff write pending".
+
+### Step 5: Close session
 
 Write final state to session JSON:
 - Set `checkpoint: "closed"`
+- Set `eod_handoff_written: true` (if Step 4 succeeded)
 - Atomic write + re-render dashboard
 
-Confirm: "Day closed. Deferred tasks will carry over tomorrow."
+Confirm: "Day closed. Handoff written to `~/.workplanner/profiles/<name>/handoffs/YYYY-MM-DD.md`. Deferred tasks will carry over tomorrow with their reasons."

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -245,6 +245,33 @@ Create `current-session.json` with the schema from `${CLAUDE_PLUGIN_ROOT}/docs/s
 
 Use atomic writes (tmp file → mv) for ALL state mutations.
 
+### Step 0.25: Read yesterday's handoff doc
+
+Before the inbox sweep, read yesterday's local handoff doc (written by `/eod` the previous day):
+
+```bash
+# Resolve yesterday's date in the profile's timezone (same logic as sweep_since).
+YESTERDAY=$(python3 -c "
+from datetime import timedelta
+import json, os, sys
+sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT}/bin')
+from transition import local_today, load_config
+print((local_today(load_config()) - timedelta(days=1)).isoformat())
+")
+python3 "${CLAUDE_PLUGIN_ROOT}/bin/handoff.py" read --date "$YESTERDAY"
+```
+
+The output is a JSON blob with `sections` (aggregated across all session sub-sections), `deferred` (parsed list of `{title, uid, reason, session}` dicts), and `raw` (the full markdown for fallback).
+
+**What to do with it:**
+
+- **Deferred list** (`.deferred`) feeds the carryover mini-triage (see Step 3 below).
+- **Open questions** → include in the morning headlines so they surface early ("Open from yesterday: <question>").
+- **Context for tomorrow** → treat as LLM-addressed notes to self; read once, apply as pre-conditioning for the day ahead. Optionally surface top items in headlines.
+- **Session trajectory** → contextual only; used to inform decisions but not re-shown verbatim in the agenda.
+
+If the file is missing (fresh install, or yesterday's /eod didn't run), proceed with a log line "No handoff for yesterday" and rely on session-JSON carryover as before.
+
 ### Step 0.5: Pre-work activity scan
 
 If `config.triage.pre_work` exists, scan for work the user already did this morning before running `/start`. This recognizes the natural pattern of checking Slack, replying to threads, and reading team blogs before formal planning.
@@ -302,7 +329,21 @@ Apply the triage framework from `${CLAUDE_PLUGIN_ROOT}/docs/triage-framework.md`
 1. **Deduplicate** — Match by `dedupe_key`. Merge: keep highest priority, combine context
 2. **Triage & Prioritize** — Assign priority tiers using `config.triage.source_priority` (or defaults). Assign estimates using `config.triage.estimates` (or defaults). Runtime overrides: `overdue: true` → critical; `due_date == today` → at least high.
 3. **"Waiting on you"** — Identify items where someone is blocked on a response (source: `slack-ping`, `github` review request, `linear` with recent user-mentioning comment). Surface as a distinct block in the agenda output (max 3). These are also in the task list at their normal priority.
-4. **Deferral reckoning** — For carryover items where `deferral_count >= config.triage.deferrals.reckoning_threshold` (default: 3), present a reckoning prompt: break down, delegate, drop, timebox, or keep. Apply the user's decision before proceeding.
+4. **Carryover mini-triage** — For every carryover task (whether or not it's at the deferral threshold), surface its `defer_reason` from yesterday's handoff + task state inline. Ask, for each: "does this still matter? re-prioritize / re-scope / send to backlog / keep as-is?" This is the lightweight check that prevents deferred items from silently re-entering the agenda without reconsideration. Apply the user's answer via the appropriate `wpl` command (`wpl remove t<N>`, `wpl backlog --from t<N> --target <date>`, or just leave the task in place). If a task is at `deferral_count >= config.triage.deferrals.reckoning_threshold` (default: 3), escalate to the full reckoning prompt: break down, delegate, drop, timebox, or keep.
+
+   The carryover triage must present `defer_reason` alongside each task, because without that context the "does this still matter?" question has no anchor. Example presentation:
+
+   ```
+   Carryover from yesterday:
+   1. Review Stéphane's PR (t3 est ~30m, ref: HAL-123)
+      Reason yesterday: "waiting on Stéphane to push fixture refactor"
+      Keep / defer / drop / backlog / re-scope?
+   2. Update API docs (t5 est ~15m)
+      Reason yesterday: "underspecified — what do we actually want to document?"
+      Keep / defer / drop / backlog / re-scope?
+   ```
+
+   Record outcomes. If the user says "defer again" with a new reason, pass it via `wpl defer --reason "..."` so the updated reason lives on the task.
 5. **Filter** — Always: critical, high, overdue, due-today. Medium if budget allows. Cap at `config.triage.filter.task_cap` (default: 10) tasks.
 6. **Order** — Per `config.triage.ordering` (default: critical → high → medium → focus). Carryover ordered by its assigned tier, not auto-first.
 7. **Time structure** — Insert `config.protected_blocks` + `session.calendar_events`. Compute budget.


### PR DESCRIPTION
## Summary

Stream B of the comprehensive workplanner pass. Ships cross-session narrative: every deferred task now carries a `defer_reason`, every `/eod` writes a local handoff markdown file, every next-morning `/start` reads it and runs a carryover mini-triage that surfaces each deferred task's reason inline.

Closes the loop described in [issue #3](https://github.com/melek/workplanner/issues/3) (scoped-down per interview Q5 — no workspace decisions register inside workplanner) and [issue #4](https://github.com/melek/workplanner/issues/4) (morning carryover mini-triage).

## What's new

**`defer_reason` field on tasks** — `wpl defer --reason "…"` records a one-line explanation. The reason:
- Persists on the task (migration-safe via `.get()`)
- Travels across carryover (session → backlog → session via `--promote`)
- Is surfaced at the reckoning-threshold prompt and in every `defer`/`reckon` output line
- Is also writable via `wpl reckon <choice> --reason "…"`

**Local handoff doc** — `~/.workplanner/profiles/<resolved-profile-name>/handoffs/YYYY-MM-DD.md`:
- Merge-by-section format: `## Session trajectory`, `## Deferred with reasons`, `## Open questions`, `## Context for tomorrow`
- Each section further split into `### <session-id>` sub-sections so concurrent sessions (dispatched tmux panes, multiple Claude instances) don't clobber each other
- Session ID picked from `$CLAUDE_SESSION_ID` → `$TMUX_PANE` → process-start-hash fallback
- Unknown `## ...` sections (e.g., human free-text additions) pass through untouched
- Library: `bin/handoff.py write|read|path`
- Path uses concrete profile name, never the `active` alias — sidesteps the symlink-race (issue #10) for this artifact

**`/eod` Step 4 (new)** — calls `handoff.py write` to record this session's contribution. Idempotent within a session-id. Session state gains `eod_handoff_written` as a distinct checkpoint from `eod_posted`.

**`/start` Step 0.25 (new)** — reads yesterday's handoff via `handoff.py read` before the inbox sweep; its `deferred` list feeds the carryover mini-triage in the triage pipeline. Each carryover task is presented with its `defer_reason` and asked "keep / defer / drop / backlog / re-scope?".

## Relationship to Stream A

Stream A changes mutating command stdout to include the full task list. Stream B layers on top: the `--reason` argument is the only `cmd_defer` parser addition here, and the reason-tag append to the post-defer print line is a small addition after the remaining-summary. If Stream A introduces a `format_task_list` helper, rebasing should be clean — the two changes touch different parts of `cmd_defer`.

## Verification (run in /tmp test profile, not touching user's real state)

All four scenarios from the brief pass:

1. Simulated day with two deferred tasks (each with a reason). `handoff.py write` produces the expected markdown file, each reason inline under the session sub-section.
2. A second session (`TMUX_PANE=%3`) wrote its own contribution; re-running EOD from the first session (`TMUX_PANE=%0`) rewrote only pane-0's sub-sections — pane-3's survived. Human-added `## Notes` block also preserved verbatim.
3. `/start` equivalent (`handoff.py read --date 2026-04-21`) returned a parsed `deferred` list with `{title, uid, reason, session}` for three deferred tasks across two panes.
4. `wpl defer --reason "…"` at threshold (3rd defer) surfaced both new and prior reasons in the reckoning prompt. `wpl reckon k`, `b`, `d`, `t` each carry the reason into their output line and/or into the backlog item. `backlog --promote` round-trips `defer_reason` and `deferral_count` back onto the session task.
5. Legacy session JSON without `uid` or `defer_reason` continues to work (`backfill_uids` adds uid; `.get()` keeps defer_reason absent-safe).

## Files changed

- `bin/transition.py` — `cmd_defer` / `cmd_reckon` gain `--reason`; `_move_task_to_backlog` and `_backlog_promote` carry `defer_reason` + `deferral_count`; `resolve_paths()` exposes `PROFILE_NAME` and `HANDOFFS`
- `bin/handoff.py` (new) — read/write library + CLI
- `skills/eod/SKILL.md` — five-step procedure; new Step 4 (write handoff)
- `skills/start/SKILL.md` — new Step 0.25 (read handoff); carryover mini-triage with reason surfacing
- `docs/state-schema.md` — new handoff-doc section; `defer_reason` / `deferral_count` on task + backlog schemas; `eod_handoff_written` on session schema
- `docs/eod-consolidation.md` — renumbered steps; new Step 4
- `docs/morning-assembly.md` — Step 0.25 entry; triage pipeline renumbered with mini-triage step

## Test plan

- [ ] End-to-end: simulate a day with deferred tasks; `/eod`; next day's `/start` presents them with reasons.
- [ ] Concurrent-write safety: dispatch a sub-session, have it also write handoff; verify both sub-sections coexist.
- [ ] Hand-edit safety: drop a `## Notes` section into the handoff; re-run `/eod`; verify notes survive.
- [ ] Reckoning surfaces prior reason when defer at threshold is called without `--reason`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)