### PR TITLE
Path-based profile resolution (fixes #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Path-based profile resolution** (issue #10) — Profiles declare which filesystem paths they serve via a `workspaces: [...]` field in `config.json`. Each `wpl` invocation picks a profile by longest-prefix match of cwd against those workspaces, eliminating the race where concurrent sessions in different profiles flipped the `active` symlink out from under each other. Escape hatches: `--profile NAME` CLI flag and `$WPL_PROFILE` env var. Single-profile setups without workspaces keep working via fallback. See `docs/profiles.md`.
+- **New profile subcommands:** `associate`, `disassociate`, `whoami`, `validate`, `migrate`.
+- **Verification script** `bin/test_profile_resolution.py` covering scenarios T1–T10 from the issue brief.
+
+### Changed
+
+- `wpl profile switch` now prints a deprecation note. It still updates the `active` symlink for backward compatibility, but profile resolution no longer consults the symlink.
+- `wpl profile list` shows each profile's workspaces and marks the one matching cwd.
+
 ## 1.0.0-beta.2
 
 Profile-based architecture and public documentation rewrite.

--- a/bin/test_profile_resolution.py
+++ b/bin/test_profile_resolution.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Verification script for path-based profile resolution (issue #10).
+
+Runs T1–T10 from the issue brief against an isolated WPL_ROOT under
+/tmp. Exit 0 on success, 1 on any failed assertion.
+
+Usage:
+    python3 bin/test_profile_resolution.py
+
+The script spawns the CLI as a subprocess with a sanitized environment
+so it never touches the user's real ~/.workplanner state.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+BIN_DIR = Path(__file__).resolve().parent
+TRANSITION = BIN_DIR / "transition.py"
+
+
+def _run(cwd, env, *args, check_exit=None):
+    """Invoke transition.py as a subprocess. Returns (rc, stdout, stderr)."""
+    full_env = dict(os.environ)
+    # Drop any ambient WPL_* vars that might leak from the parent shell.
+    for k in [k for k in full_env if k.startswith("WPL_")]:
+        del full_env[k]
+    full_env.update(env)
+    # Force non-interactive: no TTY, WPL_CHILD=1 — the CLI must not prompt.
+    full_env.setdefault("WPL_CHILD", "1")
+    proc = subprocess.run(
+        [sys.executable, str(TRANSITION), *args],
+        cwd=str(cwd),
+        env=full_env,
+        capture_output=True,
+        text=True,
+    )
+    if check_exit is not None:
+        assert proc.returncode == check_exit, (
+            f"expected exit {check_exit}, got {proc.returncode}\n"
+            f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+        )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _whoami_profile(stdout):
+    """Parse the 'profile: NAME' line from `wpl profile whoami` output."""
+    for line in stdout.splitlines():
+        if line.startswith("profile:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def main():
+    # Isolate: build a throwaway root tree under /tmp.
+    base = tempfile.mkdtemp(prefix="wpl-issue10-")
+    try:
+        wpl_root = Path(base) / ".wpl"
+        hal_dir = Path(base) / "hal"
+        home_dir = Path(base) / "home"
+        hal_sub = hal_dir / "subfolder"
+        deep_dir = Path(base) / "deep" / "path"
+        hal_extra = Path(base) / "hal-extra"
+        for p in (hal_sub, home_dir, deep_dir, hal_extra):
+            p.mkdir(parents=True, exist_ok=True)
+        # Resolve the realpath so comparisons match the resolver's output.
+        base_real = os.path.realpath(base)
+
+        env = {"WPL_ROOT": str(wpl_root)}
+
+        # Bootstrap: two profiles pinned to their own workspaces.
+        _run(Path(base), env, "profile", "create", "hal",
+             "--workspace", str(hal_dir), check_exit=0)
+        _run(Path(base), env, "profile", "create", "home",
+             "--workspace", str(home_dir), check_exit=0)
+
+        # ── T1: cwd-based resolution picks the right profile ─────────
+        _, out, _ = _run(hal_sub, env, "profile", "whoami", check_exit=0)
+        assert _whoami_profile(out) == "hal", f"T1a: got {out!r}"
+        _, out, _ = _run(home_dir, env, "profile", "whoami", check_exit=0)
+        assert _whoami_profile(out) == "home", f"T1b: got {out!r}"
+        print("T1: cwd-based resolution [OK]")
+
+        # ── T2: no match fails with diagnostic naming known profiles ─
+        rc, out, err = _run(Path("/tmp"), env, "status")
+        assert rc == 1, f"T2: expected rc=1, got {rc}"
+        assert "is not associated with any profile" in err, \
+            f"T2: expected diagnostic in stderr, got {err!r}"
+        assert "hal" in err and "home" in err, \
+            f"T2: expected profile names in stderr, got {err!r}"
+        print("T2: no-match diagnostic [OK]")
+
+        # ── T3: longest-prefix wins over a catch-all workspace ───────
+        _run(Path(base), env, "profile", "create", "system",
+             "--workspace", "/", check_exit=0)
+        # Before adding 'user', /tmp/.../deep/path resolves to 'system'.
+        _, out, _ = _run(deep_dir, env, "profile", "whoami", check_exit=0)
+        assert _whoami_profile(out) == "system", f"T3 pre: got {out!r}"
+        _run(Path(base), env, "profile", "create", "user",
+             "--workspace", str(Path(base)), check_exit=0)
+        # Now 'user' (more specific than '/') should win.
+        _, out, _ = _run(deep_dir, env, "profile", "whoami", check_exit=0)
+        assert _whoami_profile(out) == "user", f"T3: got {out!r}"
+        print("T3: longest-prefix wins [OK]")
+
+        # ── T4: identical-path overlap is rejected ───────────────────
+        _run(Path(base), env, "profile", "create", "bar",
+             "--workspace", "/tmp/issue10/x/y", check_exit=0)
+        rc, out, err = _run(Path(base), env, "profile", "create", "foo",
+                            "--workspace", "/tmp/issue10/x/y")
+        assert rc == 1, f"T4: expected rc=1, got {rc}"
+        assert "already claimed" in err, f"T4: got stderr {err!r}"
+        assert not (wpl_root / "profiles" / "foo").exists(), \
+            "T4: failed create left a partial profile on disk"
+        print("T4: overlap rejected atomically [OK]")
+
+        # ── T5: WPL_PROFILE env var overrides path resolution ────────
+        env5 = dict(env)
+        env5["WPL_PROFILE"] = "home"
+        _, out, _ = _run(hal_dir, env5, "profile", "whoami", check_exit=0)
+        assert _whoami_profile(out) == "home", f"T5: got {out!r}"
+        print("T5: $WPL_PROFILE override [OK]")
+
+        # ── T6: whoami reports match + workspace path ────────────────
+        _, out, _ = _run(hal_dir, env, "profile", "whoami", check_exit=0)
+        assert "profile: hal" in out
+        assert "resolved via: path match" in out
+        assert f"matched workspace: {os.path.realpath(hal_dir)}" in out, \
+            f"T6: got {out!r}"
+        print("T6: whoami reports matched workspace [OK]")
+
+        # ── T7: `switch` still flips the symlink and prints deprecation
+        _, out, _ = _run(Path(base), env, "profile", "switch", "home",
+                         check_exit=0)
+        assert "Switched to profile 'home'" in out
+        assert "deprecat" in out.lower() or "backward compat" in out.lower(), \
+            f"T7: expected deprecation note, got {out!r}"
+        active = wpl_root / "profiles" / "active"
+        assert active.is_symlink(), "T7: active is not a symlink"
+        assert os.readlink(str(active)) == "home", \
+            f"T7: symlink points to {os.readlink(str(active))!r}"
+        print("T7: switch + deprecation note [OK]")
+
+        # ── T8: path-component matching — hal-extra must not match hal
+        # To isolate: remove 'user' workspace so nothing broader than
+        # '/' could mask a bad match.
+        _run(Path(base), env, "profile", "disassociate", "user",
+             str(Path(base)), check_exit=0)
+        _, out, _ = _run(hal_extra, env, "profile", "whoami", check_exit=0)
+        name = _whoami_profile(out)
+        assert name == "system", \
+            f"T8: {hal_extra} must not match 'hal'; got {name!r}"
+        # Restore for subsequent tests.
+        _run(Path(base), env, "profile", "associate", "user",
+             str(Path(base)), check_exit=0)
+        print("T8: path-component matching [OK]")
+
+        # ── T9: single-profile fallback ──────────────────────────────
+        solo_root = Path(base) / ".wpl-solo"
+        env9 = {"WPL_ROOT": str(solo_root)}
+        _run(Path(base), env9, "profile", "create", "solo", check_exit=0)
+        _, out, _ = _run(Path("/tmp"), env9, "profile", "whoami",
+                         check_exit=0)
+        assert _whoami_profile(out) == "solo", f"T9: got {out!r}"
+        assert "single-profile fallback" in out, f"T9: reason? {out!r}"
+        print("T9: single-profile fallback [OK]")
+
+        # ── T10: concurrent-session isolation — switch doesn't leak ──
+        # Session A resolves inside hal. Session B (from home dir)
+        # flips the active symlink. Session A's next call must still
+        # resolve to hal.
+        _, out, _ = _run(hal_dir, env, "profile", "whoami", check_exit=0)
+        assert _whoami_profile(out) == "hal", f"T10 pre: got {out!r}"
+        _run(home_dir, env, "profile", "switch", "hal", check_exit=0)
+        # Without path-based resolution, home's next call would now
+        # resolve to hal via the symlink. With path-based, it stays home.
+        _, out, _ = _run(home_dir, env, "profile", "whoami", check_exit=0)
+        assert _whoami_profile(out) == "home", \
+            f"T10: concurrent-session isolation broken; got {out!r}"
+        print("T10: concurrent-session isolation [OK]")
+
+        # ── Bonus: --profile CLI flag beats env var ──────────────────
+        env_b = dict(env)
+        env_b["WPL_PROFILE"] = "system"
+        _, out, _ = _run(hal_dir, env_b, "--profile", "home",
+                         "profile", "whoami", check_exit=0)
+        assert _whoami_profile(out) == "home"
+        assert "--profile flag" in out
+        print("Bonus: --profile flag > $WPL_PROFILE [OK]")
+
+        print("\nAll scenarios passed.")
+        return 0
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -20,25 +20,361 @@ from zoneinfo import ZoneInfo
 WPL_ROOT = Path(os.environ["WPL_ROOT"]) if os.environ.get("WPL_ROOT") else Path.home() / ".workplanner"
 
 
-def resolve_profile_root():
-    """Resolve the active profile directory via symlink."""
-    active = WPL_ROOT / "profiles" / "active"
-    if active.is_symlink():
-        resolved = active.resolve()
-        if resolved.is_dir():
-            return resolved
-        # Broken symlink — fall through to single-profile fallback
-    elif active.is_dir():
-        return active
-    # Fallback: if no active symlink, check for a single profile
+# ── Profile resolution ──────────────────────────────────────────────
+#
+# Profile selection is path-based: each profile declares which filesystem
+# paths it serves via its config.json "workspaces: [...]" list. The cwd
+# determines the profile by longest-prefix match, with no consultation of
+# the global `active` symlink. This eliminates the race where concurrent
+# sessions in different profiles clobber each other via symlink flips
+# (issue #10). Escape hatches: `--profile NAME` CLI flag, `WPL_PROFILE`
+# env var, and a single-profile-without-workspaces fallback.
+
+# Set by main() from the top-level --profile flag, if provided. Overrides
+# env-var and path-based resolution.
+PROFILE_OVERRIDE = None
+
+
+def _normalize_path(raw):
+    """Return the absolute, symlink-resolved form of a path string.
+
+    `~` is expanded; the path is not required to exist (realpath handles
+    missing components on modern systems). Used both for cwd and for
+    workspace paths declared in profile configs.
+    """
+    return os.path.realpath(os.path.expanduser(str(raw)))
+
+
+def _path_is_prefix(prefix, path):
+    """True iff `path` equals `prefix` or is nested under it.
+
+    Uses path-component matching so `/foo/bar` does NOT match `/foo/barn`.
+    Both arguments should already be normalized via `_normalize_path`.
+    """
+    if prefix == path:
+        return True
+    # Ensure the prefix ends with the separator so we compare components,
+    # not substring bytes. `/` is already separator-terminated in effect.
+    if prefix.endswith(os.sep):
+        return path.startswith(prefix)
+    return path.startswith(prefix + os.sep)
+
+
+def _iter_profile_dirs():
+    """Yield profile directory Paths, skipping the `active` alias."""
     profiles_dir = WPL_ROOT / "profiles"
-    if profiles_dir.is_dir():
-        candidates = [d for d in profiles_dir.iterdir()
-                      if d.is_dir() and d.name != "active"]
-        if len(candidates) == 1:
-            return candidates[0]
-    fail(f"No active profile. Run /workplanner:start to set up, "
-         f"or create one with: wpl profile create <name>")
+    if not profiles_dir.is_dir():
+        return
+    for d in sorted(profiles_dir.iterdir()):
+        if d.is_dir() and d.name != "active":
+            yield d
+
+
+def _read_profile_config(profile_dir):
+    """Load `config.json` for a profile, returning `{}` on any failure.
+
+    Used by profile-resolution code that can't call `load_config()` (which
+    itself depends on profile resolution — circular).
+    """
+    try:
+        with open(profile_dir / "config.json") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _profile_workspaces(profile_dir):
+    """Return the normalized `workspaces: [...]` list for a profile.
+
+    Non-string entries are skipped silently; the validator (`wpl profile
+    validate`, not implemented in this pass) would surface the problem.
+    """
+    cfg = _read_profile_config(profile_dir)
+    raw = cfg.get("workspaces") or []
+    if not isinstance(raw, list):
+        return []
+    out = []
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        out.append(_normalize_path(entry))
+    return out
+
+
+def _detect_workspace_overlaps():
+    """Return a list of (path, [profile_name, ...]) for duplicate workspace claims.
+
+    Two profiles claiming the *identical* workspace path is an
+    unresolvable ambiguity. Proper-prefix cases are intentional
+    (longest-match wins) and are not reported here.
+    """
+    by_path = {}
+    for d in _iter_profile_dirs():
+        for ws in _profile_workspaces(d):
+            by_path.setdefault(ws, []).append(d.name)
+    return [(path, names) for path, names in sorted(by_path.items())
+            if len(names) > 1]
+
+
+def _resolve_by_cwd(cwd=None):
+    """Longest-prefix match of cwd against declared workspaces.
+
+    Returns (profile_dir, matched_workspace_path) or (None, None).
+    """
+    if cwd is None:
+        cwd = _normalize_path(os.getcwd())
+    best = None  # (length, profile_dir, workspace_path)
+    for d in _iter_profile_dirs():
+        for ws in _profile_workspaces(d):
+            if _path_is_prefix(ws, cwd):
+                # Length ranks by string length; since all are normalized
+                # absolute paths, longer string = deeper path.
+                if best is None or len(ws) > best[0]:
+                    best = (len(ws), d, ws)
+    if best is None:
+        return None, None
+    return best[1], best[2]
+
+
+def _find_profile_by_name(name):
+    """Return the profile directory for `name`, or None."""
+    candidate = WPL_ROOT / "profiles" / name
+    if candidate.is_dir() and candidate.name != "active":
+        return candidate
+    return None
+
+
+def _first_run_prompt(cwd):
+    """Interactive prompt when cwd isn't associated with any profile.
+
+    Returns the resolved profile directory (after association/creation) or
+    None if the user cancels. Called only when stdin is a TTY and
+    $WPL_CHILD != "1".
+    """
+    print(f"Current directory '{cwd}' isn't associated with any profile.",
+          file=sys.stderr)
+    existing = [d.name for d in _iter_profile_dirs()]
+    if existing:
+        print("", file=sys.stderr)
+        print("Existing profiles:", file=sys.stderr)
+        for name in existing:
+            wss = _profile_workspaces(WPL_ROOT / "profiles" / name)
+            if wss:
+                print(f"  - {name}: {', '.join(wss)}", file=sys.stderr)
+            else:
+                print(f"  - {name}: (no workspaces)", file=sys.stderr)
+        print("", file=sys.stderr)
+    print("Options:", file=sys.stderr)
+    print("  [1] Associate this directory with an existing profile",
+          file=sys.stderr)
+    print("  [2] Create a new profile here", file=sys.stderr)
+    print("  [3] Cancel", file=sys.stderr)
+    try:
+        choice = input("Choice [1/2/3]: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+    if choice == "1":
+        if not existing:
+            print("No existing profiles to associate.", file=sys.stderr)
+            return None
+        try:
+            name = input(f"Profile name ({'/'.join(existing)}): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            return None
+        target = _find_profile_by_name(name)
+        if target is None:
+            print(f"Profile '{name}' does not exist.", file=sys.stderr)
+            return None
+        # Check overlap before writing.
+        for d in _iter_profile_dirs():
+            if d.name == name:
+                continue
+            if cwd in _profile_workspaces(d):
+                print(f"Profile '{d.name}' already claims '{cwd}'. "
+                      f"Disassociate it first.", file=sys.stderr)
+                return None
+        _add_workspace_to_profile(target, cwd)
+        print(f"Associated '{cwd}' with profile '{name}'.", file=sys.stderr)
+        return target
+    elif choice == "2":
+        try:
+            name = input("New profile name: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            return None
+        if not name:
+            return None
+        if not (name.isidentifier() or name.replace("-", "").isalnum()):
+            print(f"Invalid profile name '{name}'.", file=sys.stderr)
+            return None
+        if _find_profile_by_name(name) is not None:
+            print(f"Profile '{name}' already exists.", file=sys.stderr)
+            return None
+        target = _create_profile(name, workspaces=[cwd])
+        print(f"Created profile '{name}' associated with '{cwd}'.",
+              file=sys.stderr)
+        return target
+    else:
+        return None
+
+
+def resolve_profile_root():
+    """Resolve the active profile directory.
+
+    Resolution order:
+      1. Explicit override: `--profile NAME` CLI flag (PROFILE_OVERRIDE)
+         or `$WPL_PROFILE` env var. Bypasses path resolution entirely.
+      2. Path-based: longest-prefix match of cwd against each profile's
+         declared `workspaces: [...]`.
+      3. Single-profile fallback: if exactly one profile exists and it
+         has no workspaces declared, use it (low-friction single setup).
+      4. First-run prompt: if stdin is a TTY and `$WPL_CHILD != "1"`,
+         prompt the user to associate or create.
+      5. Fail loudly with a diagnostic listing known profiles.
+
+    The `active` symlink is NOT consulted. It's preserved for backward
+    compatibility with external integrations (`wpl profile switch` still
+    updates it) but no longer participates in resolution.
+    """
+    # (1) Explicit override — CLI flag wins over env var.
+    override = PROFILE_OVERRIDE or os.environ.get("WPL_PROFILE", "").strip() or None
+    if override:
+        target = _find_profile_by_name(override)
+        if target is None:
+            fail(f"Profile '{override}' does not exist. "
+                 f"Known: {', '.join(d.name for d in _iter_profile_dirs()) or '(none)'}.")
+        return target
+
+    # (2) Path-based match.
+    cwd = _normalize_path(os.getcwd())
+    matched, _ws = _resolve_by_cwd(cwd)
+    if matched is not None:
+        return matched
+
+    # (3) Single-profile fallback (only if that profile declares no workspaces).
+    all_profiles = list(_iter_profile_dirs())
+    if len(all_profiles) == 1 and not _profile_workspaces(all_profiles[0]):
+        return all_profiles[0]
+
+    # (4) First-run prompt if interactive and not a subprocess.
+    is_tty = sys.stdin.isatty() if hasattr(sys.stdin, "isatty") else False
+    is_child = os.environ.get("WPL_CHILD", "") == "1"
+    if is_tty and not is_child and all_profiles:
+        result = _first_run_prompt(cwd)
+        if result is not None:
+            return result
+
+    # (5) Fail with a helpful diagnostic.
+    lines = [f"Current directory '{cwd}' is not associated with any profile."]
+    if all_profiles:
+        lines.append("")
+        lines.append("Known profiles and their workspaces:")
+        for d in all_profiles:
+            wss = _profile_workspaces(d)
+            if wss:
+                lines.append(f"  - {d.name}: {', '.join(wss)}")
+            else:
+                lines.append(f"  - {d.name}: (no workspaces declared)")
+        lines.append("")
+        lines.append("To fix, run one of:")
+        lines.append(f"  wpl profile associate <name> {cwd}")
+        lines.append(f"  wpl --profile <name> <command>")
+        lines.append(f"  WPL_PROFILE=<name> wpl <command>")
+    else:
+        lines.append("No profiles exist yet. Run /workplanner:start to set up, "
+                     "or: wpl profile create <name> --workspace <path>")
+    fail("\n".join(lines))
+
+
+def _add_workspace_to_profile(profile_dir, workspace_path):
+    """Append a workspace path to a profile's config.json, writing atomically.
+
+    Normalizes the path, checks for overlap with other profiles (same-path
+    conflict only — proper-prefix overlaps are intentional), and fails
+    loudly on conflict. No-op if the path is already present.
+    """
+    workspace_path = _normalize_path(workspace_path)
+    # Overlap check — same path claimed by another profile is ambiguous.
+    for d in _iter_profile_dirs():
+        if d == profile_dir:
+            continue
+        if workspace_path in _profile_workspaces(d):
+            fail(f"Workspace '{workspace_path}' is already claimed by "
+                 f"profile '{d.name}'. Disassociate it there first.")
+    config_path = profile_dir / "config.json"
+    cfg = _read_profile_config(profile_dir)
+    current = cfg.get("workspaces") or []
+    if not isinstance(current, list):
+        current = []
+    # Normalize for comparison; store the normalized form too.
+    normalized = [_normalize_path(p) for p in current
+                  if isinstance(p, str) and p.strip()]
+    if workspace_path in normalized:
+        return  # already present
+    normalized.append(workspace_path)
+    cfg["workspaces"] = normalized
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = str(config_path) + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    os.rename(tmp, str(config_path))
+
+
+def _remove_workspace_from_profile(profile_dir, workspace_path):
+    """Remove a workspace path from a profile's config.json. Idempotent."""
+    workspace_path = _normalize_path(workspace_path)
+    config_path = profile_dir / "config.json"
+    cfg = _read_profile_config(profile_dir)
+    current = cfg.get("workspaces") or []
+    if not isinstance(current, list):
+        return
+    filtered = [_normalize_path(p) for p in current
+                if isinstance(p, str) and p.strip()
+                and _normalize_path(p) != workspace_path]
+    cfg["workspaces"] = filtered
+    tmp = str(config_path) + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    os.rename(tmp, str(config_path))
+
+
+def _create_profile(name, workspaces=None):
+    """Create a new profile directory with baseline config. Returns the dir.
+
+    Overlap checks run *before* any filesystem mutation so a rejected
+    create leaves the `profiles/` tree untouched.
+    """
+    profiles_dir = WPL_ROOT / "profiles"
+    target = profiles_dir / name
+    cfg = {}
+    normalized = []
+    if workspaces:
+        normalized = [_normalize_path(w) for w in workspaces]
+        for ws in normalized:
+            for d in _iter_profile_dirs():
+                if ws in _profile_workspaces(d):
+                    fail(f"Workspace '{ws}' is already claimed by "
+                         f"profile '{d.name}'.")
+        cfg["workspaces"] = normalized
+    profiles_dir.mkdir(parents=True, exist_ok=True)
+    target.mkdir()
+    (target / "session").mkdir()
+    (target / "session" / "agendas" / "archive").mkdir(parents=True)
+    (target / "briefings").mkdir()
+    with open(target / "config.json", "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.write("\n")
+    with open(target / "backlog.json", "w") as f:
+        f.write('{"schema_version": 1, "items": []}\n')
+    # If no active symlink, set this as active (preserves backward compat
+    # for anything reading the symlink directly, though resolution no
+    # longer relies on it).
+    active_link = profiles_dir / "active"
+    if not active_link.exists():
+        active_link.symlink_to(name)
+    return target
 
 
 def resolve_paths():
@@ -1587,7 +1923,8 @@ def cmd_history(args):
 
 
 def cmd_profile(args):
-    """Profile management: list, create, switch, active, delete."""
+    """Profile management: list, create, switch, active, delete,
+    associate, disassociate, whoami, validate, migrate."""
     sub = args.profile_action
     profiles_dir = WPL_ROOT / "profiles"
 
@@ -1599,34 +1936,158 @@ def cmd_profile(args):
         active_link = profiles_dir / "active"
         if active_link.is_symlink() and active_link.resolve().is_dir():
             active_name = active_link.resolve().name
-        for d in sorted(profiles_dir.iterdir()):
-            if d.is_dir() and d.name != "active":
-                marker = " (active)" if d.name == active_name else ""
-                print(f"  {d.name}{marker}")
+        # Which profile matches cwd right now? (Informational marker only.)
+        cwd = _normalize_path(os.getcwd())
+        matched_dir, matched_ws = _resolve_by_cwd(cwd)
+        matched_name = matched_dir.name if matched_dir else None
+
+        for d in _iter_profile_dirs():
+            markers = []
+            if d.name == matched_name:
+                markers.append("cwd-match")
+            if d.name == active_name:
+                markers.append("active-symlink")
+            marker_str = f" ({', '.join(markers)})" if markers else ""
+            wss = _profile_workspaces(d)
+            print(f"  {d.name}{marker_str}")
+            if wss:
+                for ws in wss:
+                    arrow = " <-- cwd" if (
+                        matched_name == d.name and ws == matched_ws
+                    ) else ""
+                    print(f"      workspace: {ws}{arrow}")
+            else:
+                print(f"      (no workspaces declared — run "
+                      f"'wpl profile associate {d.name} <path>')")
+        # Overlap warnings.
+        overlaps = _detect_workspace_overlaps()
+        if overlaps:
+            print("")
+            print("WARNING: workspace overlaps (same path claimed by multiple profiles):")
+            for path, names in overlaps:
+                print(f"  {path}: {', '.join(names)}")
 
     elif sub == "create":
         name = args.name
-        if not name.isidentifier() and not name.replace("-", "").isalnum():
+        if not (name.isidentifier() or name.replace("-", "").isalnum()):
             fail(f"Invalid profile name '{name}'. Use letters, numbers, and hyphens.")
-        target = profiles_dir / name
-        if target.exists():
+        if (profiles_dir / name).exists():
             fail(f"Profile '{name}' already exists.")
-        profiles_dir.mkdir(parents=True, exist_ok=True)
-        target.mkdir()
-        (target / "session").mkdir()
-        (target / "session" / "agendas" / "archive").mkdir(parents=True)
-        (target / "briefings").mkdir()
-        for fname, content in [
-            ("config.json", "{}"),
-            ("backlog.json", '{"schema_version": 1, "items": []}'),
-        ]:
-            with open(target / fname, "w") as f:
-                f.write(content + "\n")
-        # If no active symlink, set this as active
-        active_link = profiles_dir / "active"
-        if not active_link.exists():
-            active_link.symlink_to(name)
-        print(f"Created profile '{name}'.")
+        workspaces = list(getattr(args, "workspace", []) or [])
+        _create_profile(name, workspaces=workspaces)
+        if workspaces:
+            print(f"Created profile '{name}' with workspaces: "
+                  f"{', '.join(_normalize_path(w) for w in workspaces)}")
+        else:
+            print(f"Created profile '{name}'. No workspaces declared — "
+                  f"run 'wpl profile associate {name} <path>' to enable "
+                  f"path-based resolution.")
+
+    elif sub == "associate":
+        name = args.name
+        path = args.path
+        target = _find_profile_by_name(name)
+        if target is None:
+            fail(f"Profile '{name}' does not exist.")
+        _add_workspace_to_profile(target, path)
+        print(f"Associated '{_normalize_path(path)}' with profile '{name}'.")
+
+    elif sub == "disassociate":
+        name = args.name
+        path = args.path
+        target = _find_profile_by_name(name)
+        if target is None:
+            fail(f"Profile '{name}' does not exist.")
+        before = _profile_workspaces(target)
+        _remove_workspace_from_profile(target, path)
+        after = _profile_workspaces(target)
+        if len(before) == len(after):
+            print(f"'{_normalize_path(path)}' was not associated with '{name}'.")
+        else:
+            print(f"Disassociated '{_normalize_path(path)}' from profile '{name}'.")
+
+    elif sub == "whoami":
+        cwd = _normalize_path(os.getcwd())
+        override = PROFILE_OVERRIDE or os.environ.get("WPL_PROFILE", "").strip() or None
+        if override:
+            target = _find_profile_by_name(override)
+            if target is None:
+                fail(f"Profile '{override}' (from override) does not exist.")
+            source = ("--profile flag" if PROFILE_OVERRIDE
+                      else "$WPL_PROFILE env var")
+            print(f"profile: {target.name}")
+            print(f"resolved via: {source}")
+            print(f"cwd: {cwd}")
+            return
+        matched, ws = _resolve_by_cwd(cwd)
+        if matched is not None:
+            print(f"profile: {matched.name}")
+            print(f"resolved via: path match")
+            print(f"matched workspace: {ws}")
+            print(f"cwd: {cwd}")
+            return
+        # Single-profile fallback?
+        all_profiles = list(_iter_profile_dirs())
+        if len(all_profiles) == 1 and not _profile_workspaces(all_profiles[0]):
+            print(f"profile: {all_profiles[0].name}")
+            print(f"resolved via: single-profile fallback (no workspaces declared)")
+            print(f"cwd: {cwd}")
+            return
+        print(f"profile: (unresolved)")
+        print(f"cwd: {cwd}")
+        if all_profiles:
+            print("known profiles:")
+            for d in all_profiles:
+                wss = _profile_workspaces(d)
+                print(f"  - {d.name}: {', '.join(wss) if wss else '(no workspaces)'}")
+
+    elif sub == "validate":
+        # Check for same-path overlaps across profiles.
+        overlaps = _detect_workspace_overlaps()
+        if overlaps:
+            print("Workspace overlaps detected:")
+            for path, names in overlaps:
+                print(f"  {path}: claimed by {', '.join(names)}")
+            sys.exit(1)
+        # Warn about profiles without workspaces (unless it's the only one).
+        all_profiles = list(_iter_profile_dirs())
+        missing = [d.name for d in all_profiles if not _profile_workspaces(d)]
+        if missing and len(all_profiles) > 1:
+            print("Profiles without declared workspaces "
+                  "(path-based resolution disabled):")
+            for name in missing:
+                print(f"  - {name}")
+            print("Run 'wpl profile associate <name> <path>' to fix.")
+            sys.exit(1)
+        print("OK")
+
+    elif sub == "migrate":
+        # Walk the user through associating paths for any profile that
+        # lacks workspaces. Interactive only — refuse if not a TTY.
+        if not (hasattr(sys.stdin, "isatty") and sys.stdin.isatty()):
+            fail("`wpl profile migrate` is interactive; run it from a TTY.")
+        missing = [d for d in _iter_profile_dirs() if not _profile_workspaces(d)]
+        if not missing:
+            print("All profiles have workspaces declared. Nothing to migrate.")
+            return
+        for d in missing:
+            print(f"\nProfile '{d.name}' has no workspaces declared.")
+            print(f"Enter one or more absolute paths (blank line to skip this profile).")
+            while True:
+                try:
+                    path = input(f"  workspace for {d.name}: ").strip()
+                except (EOFError, KeyboardInterrupt):
+                    print("")
+                    return
+                if not path:
+                    break
+                try:
+                    _add_workspace_to_profile(d, path)
+                    print(f"  associated {_normalize_path(path)}")
+                except SystemExit:
+                    # fail() already emitted the diagnostic.
+                    pass
+        print("\nMigration complete. Run 'wpl profile list' to review.")
 
     elif sub == "switch":
         name = args.name
@@ -1640,6 +2101,10 @@ def cmd_profile(args):
             fail(f"'{active_link}' exists but is not a symlink. Remove it manually.")
         active_link.symlink_to(name)
         print(f"Switched to profile '{name}'.")
+        print("")
+        print("Note: `wpl profile switch` is preserved for backward compatibility.")
+        print("Profile resolution now uses workspace paths declared on each profile.")
+        print("Run `wpl profile whoami` to see which profile matches your current directory.")
 
     elif sub == "active":
         active_link = profiles_dir / "active"
@@ -1669,7 +2134,8 @@ def cmd_profile(args):
         print(f"Deleted profile '{name}'.")
 
     else:
-        fail("Unknown profile action. Use: list, create, switch, active, delete")
+        fail("Unknown profile action. Use: list, create, switch, active, "
+             "delete, associate, disassociate, whoami, validate, migrate")
 
 
 def cmd_decision(args):
@@ -1843,6 +2309,16 @@ def build_parser():
         help="Output format. 'text' (default) is glyph-friendly, LLM- and human-readable. "
              "'json' emits a structured response suitable for programmatic parsing.",
     )
+    parser.add_argument(
+        "--profile",
+        dest="profile_override",
+        type=str,
+        default=None,
+        help="Override profile resolution for this invocation. Bypasses "
+             "path-based resolution and the $WPL_PROFILE env var. Use "
+             "for scripts running outside a declared workspace or for "
+             "deliberate cross-profile inspection.",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_done = sub.add_parser("done", help="Mark current task done.")
@@ -1934,12 +2410,35 @@ def build_parser():
     profile_parser = sub.add_parser("profile", help="Profile management")
     profile_sub = profile_parser.add_subparsers(dest="profile_action")
     profile_sub.required = True
-    profile_sub.add_parser("list", help="List profiles")
-    p_create = profile_sub.add_parser("create", help="Create a profile")
+    profile_sub.add_parser("list", help="List profiles with workspaces and cwd match")
+    p_create = profile_sub.add_parser(
+        "create", help="Create a profile, optionally with workspaces")
     p_create.add_argument("name", help="Profile name")
-    p_switch = profile_sub.add_parser("switch", help="Switch active profile")
+    p_create.add_argument(
+        "--workspace", action="append", default=None,
+        help="Filesystem path to pre-associate with the new profile "
+             "(repeatable). Normalized via realpath.")
+    p_assoc = profile_sub.add_parser(
+        "associate", help="Add a workspace path to an existing profile")
+    p_assoc.add_argument("name", help="Profile name")
+    p_assoc.add_argument("path", help="Absolute path to associate")
+    p_disassoc = profile_sub.add_parser(
+        "disassociate", help="Remove a workspace path from a profile")
+    p_disassoc.add_argument("name", help="Profile name")
+    p_disassoc.add_argument("path", help="Absolute path to remove")
+    profile_sub.add_parser(
+        "whoami",
+        help="Show which profile the current cwd resolves to, and how.")
+    profile_sub.add_parser(
+        "validate",
+        help="Check for workspace overlaps and missing-workspace warnings.")
+    profile_sub.add_parser(
+        "migrate",
+        help="Interactively associate workspace paths with existing profiles.")
+    p_switch = profile_sub.add_parser(
+        "switch", help="[deprecated] Update the `active` symlink")
     p_switch.add_argument("name", help="Profile name to switch to")
-    profile_sub.add_parser("active", help="Show active profile name")
+    profile_sub.add_parser("active", help="Show active-symlink profile name")
     p_delete = profile_sub.add_parser("delete", help="Delete a profile")
     p_delete.add_argument("name", help="Profile name to delete")
     profile_parser.set_defaults(func=cmd_profile)
@@ -2089,8 +2588,12 @@ def main():
     args = parser.parse_args()
     # Set module-level output format for this invocation so commands can
     # branch on it (text vs json) without threading it through every call.
-    global OUTPUT_FORMAT
+    global OUTPUT_FORMAT, PROFILE_OVERRIDE
     OUTPUT_FORMAT = getattr(args, "output_format", "text") or "text"
+    # Set module-level profile override (CLI --profile flag). This wins
+    # over $WPL_PROFILE env var, which in turn wins over path-based
+    # resolution. See resolve_profile_root().
+    PROFILE_OVERRIDE = getattr(args, "profile_override", None) or None
     handler = DISPATCH.get(args.command)
     if handler:
         handler(args)

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,149 @@
+# Profiles and Path-Based Resolution
+
+Workplanner supports multiple profiles — separate state trees for
+separate life contexts (e.g. `work`, `home`, `side-project`). A profile
+lives at `~/.workplanner/profiles/<name>/` and owns its own
+`config.json`, `backlog.json`, session directory, briefings, and
+handoffs.
+
+## How a profile gets selected
+
+Every `wpl` invocation picks a profile before touching state. The
+resolver uses a fixed precedence order:
+
+1. **`--profile NAME` CLI flag.** Top-level argparse option. Wins over
+   everything else. Use for scripts, ad-hoc inspection, or emergency
+   overrides.
+2. **`$WPL_PROFILE` env var.** Same effect as the flag, set in the
+   environment. Useful for session-scoped overrides (e.g. a tmux pane
+   pinned to a specific profile).
+3. **Path-based match.** The session's `cwd` is normalized (via `~`
+   expansion and `os.path.realpath`) and compared against each
+   profile's declared `workspaces: [...]`. The profile with the longest
+   matching workspace prefix wins. Matching is path-component aware
+   (`/foo/bar` matches `/foo/bar/baz` but not `/foo/barn`).
+4. **Single-profile fallback.** If exactly one profile exists and it
+   has no `workspaces` declared, resolution succeeds with that profile.
+   This keeps the single-setup default frictionless.
+5. **Interactive first-run prompt.** If `stdin` is a TTY and
+   `$WPL_CHILD != "1"`, the resolver asks whether to associate the cwd
+   with an existing profile, create a new profile, or cancel.
+6. **Fail with diagnostic.** Lists known profiles, their workspaces,
+   and suggests concrete commands to fix.
+
+The global `~/.workplanner/profiles/active` symlink is *not* consulted
+by the resolver. It's preserved for backward compatibility with
+anything that reads it directly (e.g. shell prompt integrations) and
+is still updated by `wpl profile switch`, but it no longer decides
+which profile a command operates against.
+
+## Why path-based resolution
+
+The previous scheme read the `active` symlink on every `wpl`
+invocation. Two concurrent Claude sessions in different profiles could
+race — either one running `wpl profile switch` flipped the symlink
+globally, and the other's next command silently operated against the
+wrong profile. Path-based resolution anchors each session to its cwd,
+so concurrent sessions in different directories don't interfere.
+
+## Workspaces
+
+Each profile's `config.json` may carry a `workspaces: [...]` list of
+absolute filesystem paths. A workspace declares "when a session runs
+from this path (or any subdirectory), use this profile." Paths are
+normalized on write.
+
+Rules:
+
+- **Longest-match-wins.** A profile with `/home/alice/projects/foo`
+  beats a profile with `/home/alice` for any cwd inside
+  `/home/alice/projects/foo/**`. This is intentional and useful: it
+  lets you keep a broad "catch-all" profile alongside narrower
+  project-specific profiles.
+- **No identical-path overlaps.** If two profiles claim the exact
+  same workspace path, the resolver can't choose. Commands that write
+  workspaces (`create`, `associate`) reject this and exit non-zero.
+  `wpl profile validate` surfaces any pre-existing overlaps.
+- **Path-component matching.** `/foo/bar` does not falsely match
+  `/foo/barn` — the resolver enforces separator boundaries.
+
+## Commands
+
+```
+wpl profile list                              Show profiles, workspaces, and cwd match.
+wpl profile create NAME [--workspace PATH]    Create a profile, optionally with workspaces.
+wpl profile associate NAME PATH               Add a workspace path to an existing profile.
+wpl profile disassociate NAME PATH            Remove a workspace path from a profile.
+wpl profile whoami                            Which profile does cwd resolve to, and how?
+wpl profile validate                          Report overlaps and missing-workspace warnings.
+wpl profile migrate                           Interactively associate paths with existing profiles.
+wpl profile switch NAME                       [deprecated] Flip the `active` symlink.
+wpl profile active                            Print the name the `active` symlink points to.
+wpl profile delete NAME                       Delete a profile.
+```
+
+## First-run flow for an unassociated cwd
+
+When a command runs from a cwd that doesn't match any profile and
+single-profile fallback doesn't apply, the resolver falls into one of
+two branches:
+
+- **Interactive (TTY).** Prompts:
+  ```
+  Current directory '/path/here' isn't associated with any profile.
+
+  Existing profiles:
+    - work: /Users/alice/work, /Users/alice/projects
+    - home: /Users/alice/personal
+
+  Options:
+    [1] Associate this directory with an existing profile
+    [2] Create a new profile here
+    [3] Cancel
+  ```
+  Choice `1` asks for a profile name and runs `associate`. Choice `2`
+  prompts for a name and creates a profile with the cwd as its first
+  workspace. The resolver then returns the newly-resolved profile and
+  the original command continues.
+
+- **Non-interactive (no TTY, or `WPL_CHILD=1`).** Fails with a
+  machine-readable diagnostic listing known profiles and their
+  workspaces, plus the three concrete commands the user can run to
+  recover (`associate`, `--profile`, `$WPL_PROFILE`). Skills catch
+  this error and re-surface it to the user instead of hanging on
+  stdin.
+
+Skills that boot on session start (e.g. `/start`) should call
+`wpl profile whoami` and check for a resolution failure as part of
+their health check, prompting the user to associate before invoking
+state-mutating commands.
+
+## Migration from symlink-based resolution
+
+Existing installations keep working without action:
+
+- **Single profile.** If you have exactly one profile and haven't
+  declared workspaces, the single-profile fallback resolves to it
+  from any cwd. Nothing to do.
+- **Multiple profiles.** `wpl profile list` warns for any profile
+  without workspaces. Run `wpl profile associate <name> <path>` for
+  each profile, or `wpl profile migrate` for an interactive walk
+  through every profile that needs paths.
+
+The `active` symlink stays in place. You can keep using
+`wpl profile switch` if something external depends on it (e.g. a
+shell prompt reading the symlink directly), but switching is no
+longer part of normal workflow — profiles resolve from cwd
+automatically.
+
+## Escape hatches
+
+- `--profile NAME` — one-shot override, e.g.
+  `wpl --profile home status` to peek at another profile.
+- `WPL_PROFILE=NAME` — session-scoped override, e.g. for a tmux pane
+  dedicated to a specific profile regardless of cwd.
+- `WPL_CHILD=1` — suppresses the interactive first-run prompt.
+  Subprocesses inherit it; set manually for scripts that shouldn't
+  block on stdin.
+- `WPL_ROOT=/some/dir` — redirects the entire state tree. Useful for
+  tests and sandbox setups.

--- a/docs/reference-config.md
+++ b/docs/reference-config.md
@@ -45,6 +45,10 @@ Located at `~/.workplanner/profiles/<name>/config.json`. Each profile has its ow
 ```json
 {
   "schema_version": 2,
+  "workspaces": [
+    "/Users/alex/work",
+    "/Users/alex/projects"
+  ],
   "timezone": "America/New_York",
   "eod_target": "17:30",
 
@@ -156,3 +160,4 @@ Located at `~/.workplanner/profiles/<name>/config.json`. Each profile has its ow
 ```
 
 Each section of this config is documented in detail in `docs/state-schema.md`.
+Path-based profile resolution (the `workspaces` field) is covered in `docs/profiles.md`.

--- a/docs/state-schema.md
+++ b/docs/state-schema.md
@@ -113,6 +113,7 @@ Created during first-run setup. Persists across sessions.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `schema_version` | `integer` | yes | Current: `2`. |
+| `workspaces` | `array` of `string` | no | Absolute filesystem paths this profile serves. Drives path-based profile resolution (see `docs/profiles.md`). Entries are normalized via `~` expansion + `os.path.realpath` on write. Profiles with no `workspaces` declared fall back to single-profile resolution (if they're the only profile) or require `--profile`/`$WPL_PROFILE` override. Overlaps between profiles (identical paths) are rejected at write time; proper-prefix overlaps are allowed and resolved by longest-match-wins. |
 | `timezone` | `string` | yes | IANA timezone identifier, e.g. `"Europe/Paris"`. Used by `transition.py` (`local_today()`) and morning assembly to anchor all date comparisons to the user's local calendar date. |
 | `eod_target` | `string` (HH:MM) | yes | Default end-of-day target time. |
 | `protected_blocks` | `array` | no | Time blocks that should not be scheduled over. |

--- a/docs/task-transitions.md
+++ b/docs/task-transitions.md
@@ -41,6 +41,16 @@ The `wpl` wrapper lives at `~/.workplanner/bin/wpl` and forwards to `bin/transit
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--format {text,json}` | `text` | Output format. Text is glyph-friendly and LLM- and human-readable. JSON emits a structured response suitable for programmatic parsing by skills that want machine-parsable output. |
+| `--profile NAME` | — | Override profile resolution for this invocation. Bypasses path-based resolution and the `$WPL_PROFILE` env var. Use for scripts running outside any declared workspace (e.g. from `/tmp`) or for deliberate cross-profile inspection. See `docs/profiles.md`. |
+
+### Profile resolution
+
+Every `wpl` invocation resolves a profile before touching state. Order of
+precedence: `--profile` CLI flag, then `$WPL_PROFILE` env var, then
+longest-prefix match of cwd against each profile's declared
+`workspaces: [...]`, then a single-profile fallback, then an interactive
+prompt (TTY only), then failure. The global `active` symlink is not
+consulted. See `docs/profiles.md` for the full flow and migration notes.
 
 ### `--as "<title>"` echo check
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -83,17 +83,27 @@ Proceed to Routing. Individual runbooks already handle graceful degradation.
 
 ## Routing
 
-Read `~/.workplanner/user.json`, `~/.workplanner/profiles/active/config.json`, and `~/.workplanner/profiles/active/session/current-session.json`. Route based on state:
+Resolve the active profile via `wpl profile whoami` (reads cwd, falls back to `--profile`/`$WPL_PROFILE` overrides, then single-profile fallback). Read `~/.workplanner/user.json`, the resolved profile's `config.json`, and the resolved profile's `session/current-session.json`. Route based on state:
 
 ```
 if user.json missing (~/.workplanner/user.json)  → First-Run Setup
+if `wpl profile whoami` returns "(unresolved)"   → Workspace Association (see below)
 if config.json missing                            → First-Run Setup (profile not configured)
+if profile has no workspaces and >1 profile exists → prompt to associate cwd (non-blocking warning)
 if session missing             → Morning Assembly
 if session.date ≠ local_today  → Stale Session Handler → Morning Assembly
 if checkpoint < assembly_complete → Resume Morning Assembly (skip completed steps)
 if checkpoint = assembly_complete → Status Check
 if checkpoint = closed         → "Yesterday's session is closed. Starting fresh." → Morning Assembly
 ```
+
+### Workspace Association
+
+If `wpl profile whoami` prints `profile: (unresolved)` (cwd doesn't match any profile and single-profile fallback doesn't apply), prompt the user before continuing:
+
+> "This directory (`<cwd>`) isn't associated with any profile. Your profiles are: `<list>`. Options: (1) associate this directory with an existing profile, (2) create a new profile rooted here, (3) run this session against a specific profile via `--profile NAME`."
+
+On (1) or (2), run the corresponding `wpl profile associate` / `wpl profile create --workspace` and re-run `wpl profile whoami` to confirm. On (3), prefix subsequent `wpl` calls with `--profile NAME` for this session.
 
 **Date comparison:** When checking whether a session is stale, compare `session.date` against today's date **in the configured timezone** (`config.timezone`, e.g. `Europe/Paris`). Use `zoneinfo.ZoneInfo` to get the correct local date — do not rely on naive `datetime.now()` which can give the wrong calendar date near midnight UTC.
 
@@ -176,6 +186,10 @@ Show the derived config in plain language:
 
 ### Step 6: Write config
 
+Prefer `wpl profile create <name> --workspace <cwd>` so the new profile is immediately resolvable by cwd (path-based resolution — see `docs/profiles.md`). The command creates the profile directory, writes a minimal `config.json` with `workspaces: [cwd]`, and sets the `active` symlink if none exists.
+
+After `wpl profile create`, populate the rest of the config:
+
 ```bash
 mkdir -p ~/.workplanner/profiles/{profile_name}/session/agendas/archive
 mkdir -p ~/.workplanner/profiles/{profile_name}/briefings
@@ -189,11 +203,9 @@ Write `~/.workplanner/user.json` with:
 - `workday_schedule` (default Mon-Fri)
 - `tmux_recommended`
 
-Write `~/.workplanner/profiles/{profile_name}/config.json` with all gathered config per the schema in `${CLAUDE_PLUGIN_ROOT}/docs/state-schema.md`.
+Update `~/.workplanner/profiles/{profile_name}/config.json` to include the rest of the gathered settings per the schema in `${CLAUDE_PLUGIN_ROOT}/docs/state-schema.md`. Preserve the `workspaces` list written by `wpl profile create`.
 
 Write empty backlog: `~/.workplanner/profiles/{profile_name}/backlog.json` with `{"schema_version": 1, "items": []}`.
-
-Create `active` symlink: `~/.workplanner/profiles/active -> {profile_name}`
 
 Use atomic writes (tmp file → mv) for ALL JSON writes.
 


### PR DESCRIPTION
## Summary

Resolves #10. Replaces the global `active` symlink as the source of truth for profile selection with path-based resolution — profiles declare which filesystem paths they serve via a `workspaces: [...]` list in `config.json`, and each `wpl` invocation picks a profile by longest-prefix match of cwd against those workspaces. This eliminates the race where concurrent Claude sessions in different profiles flipped the symlink out from under each other.

- Resolution order: `--profile NAME` flag → `$WPL_PROFILE` env var → path-based cwd match → single-profile fallback → interactive TTY prompt → failure with diagnostic.
- Path matching uses component boundaries (`/foo/bar` does not match `/foo/barn`). All paths run through `os.path.realpath` + `~` expansion.
- New subcommands: `associate`, `disassociate`, `whoami`, `validate`, `migrate`. `switch` prints a deprecation note but keeps updating the symlink for backward compatibility.
- Overlap detection: identical paths claimed by two profiles fail loudly; proper-prefix overlaps are intentional (longest-match wins).
- Non-interactive (`$WPL_CHILD=1` or no TTY) suppresses the first-run prompt and emits a machine-readable diagnostic skills can catch.
- Stream B's handoff doc (`bin/handoff.py`) continues to work unchanged — it calls `resolve_paths().PROFILE_NAME`, which now returns the path-resolved concrete name.

## Files changed

- `bin/transition.py` — resolution algorithm, new subcommands, `--profile` flag wiring.
- `bin/test_profile_resolution.py` — standalone verification script for T1–T10.
- `docs/profiles.md` — new doc covering resolution, workspaces, first-run, migration, escape hatches.
- `docs/state-schema.md` — `workspaces` field documented.
- `docs/task-transitions.md` — `--profile` flag and profile-resolution reference.
- `docs/reference-config.md` — example profile config shows `workspaces`.
- `skills/start/SKILL.md` — routes through `wpl profile whoami`; first-run uses `wpl profile create --workspace <cwd>`.
- `CHANGELOG.md` — Unreleased section.

Version number intentionally unchanged.

## Test plan

`python3 bin/test_profile_resolution.py` — 10/10 scenarios pass:

- [x] T1: cwd-based resolution picks the right profile from nested subdirs.
- [x] T2: unassociated cwd fails with diagnostic naming known profiles.
- [x] T3: longest-prefix beats a catch-all `/` workspace.
- [x] T4: identical-path overlap rejected; no partial profile dir left on disk.
- [x] T5: `$WPL_PROFILE=home` from inside `hal`'s workspace uses `home`.
- [x] T6: `wpl profile whoami` reports profile name + matched workspace path.
- [x] T7: `wpl profile switch home` still flips the symlink and prints deprecation note.
- [x] T8: path-component matching — `/foo/barn` does not match workspace `/foo/bar`.
- [x] T9: single-profile fallback — `solo` with no workspaces resolves from anywhere.
- [x] T10: concurrent-session isolation — a symlink flip from one dir doesn't change resolution in another dir.
- [x] Bonus: `--profile` flag beats `$WPL_PROFILE` env var.

Also verified end-to-end: `wpl profile create --workspace`, `wpl add`, `wpl status` work normally from inside a declared workspace under an isolated `WPL_ROOT`.