### PR TITLE
Collapse handoff mechanisms: stale-session backfill uses handoff.py (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 - `wpl profile switch` now prints a deprecation note. It still updates the `active` symlink for backward compatibility, but profile resolution no longer consults the symlink.
 - `wpl profile list` shows each profile's workspaces and marks the one matching cwd.
+- **Stale-session recovery unified with normal EOD handoff** (issue #13). `/start`'s stale-session handler now backfills a handoff at `~/.workplanner/profiles/<name>/handoffs/{stale_date}.md` using `bin/handoff.py write` — the same path `/eod` writes to on the normal path. A distinct session-id of the form `stale-recovery-{stale_date}` makes backfills visible in the file. Step 0.25 reads backfilled and normal-path handoffs identically. Re-running `/start` on a still-stale session is idempotent: if a `stale-recovery-*` sub-section is already present for the date, the handler logs "Handoff already written" and continues.
+- **External Linear posting is now orthogonal to local handoff.** The stale-session handler no longer forks between "local-handoff mode" and "external-posting mode". The local handoff is always written; a retroactive Linear post is a separate, optional decision gated on Linear MCP availability and `personal_sub_issue`.
+
+### Deprecated
+
+- `config.handoffs.dir`, `config.handoffs.filename_pattern`, and `config.handoffs.carryover_from_handoff` are deprecated and no longer read by any skill. `load_config()` emits a one-line stderr warning (at most once per process) when any of these keys is present. The keys are left untouched in the user's `config.json` — remove them when convenient to silence the warning.
 
 ## 1.0.0-beta.2
 

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -432,6 +432,42 @@ def load_user_json():
         return {}
 
 
+# Module-level flag so the deprecation warning fires at most once per process,
+# regardless of how many times load_config() is called.
+_HANDOFFS_DEPRECATION_WARNED = False
+
+
+def _warn_deprecated_handoffs_config(config):
+    """Emit a one-line stderr warning if legacy config.handoffs.* keys are present.
+
+    Fires at most once per process (module-level flag). The keys themselves are
+    left untouched in config.json — users remove them on their own schedule.
+
+    See https://github.com/melek/workplanner/issues/13.
+    """
+    global _HANDOFFS_DEPRECATION_WARNED
+    if _HANDOFFS_DEPRECATION_WARNED:
+        return
+    handoffs = config.get("handoffs") if isinstance(config, dict) else None
+    if not isinstance(handoffs, dict):
+        return
+    deprecated_keys = ("dir", "carryover_from_handoff", "filename_pattern")
+    present = [k for k in deprecated_keys if k in handoffs]
+    if not present:
+        return
+    _HANDOFFS_DEPRECATION_WARNED = True
+    # One key per message keeps the signal scannable and matches the
+    # "one-line deprecation warning" spec.
+    for k in present:
+        print(
+            f"warning: config.handoffs.{k} is deprecated and has no effect; "
+            f"handoffs now live at ~/.workplanner/profiles/<name>/handoffs/. "
+            f"See https://github.com/melek/workplanner/issues/13. "
+            f"Remove this key from config.json to silence this warning.",
+            file=sys.stderr,
+        )
+
+
 def load_config():
     """Load profile config with user.json fallback for timezone/eod_target."""
     paths = resolve_paths()
@@ -444,6 +480,7 @@ def load_config():
     for key in ("timezone", "eod_target"):
         if key not in config and key in user:
             config[key] = user[key]
+    _warn_deprecated_handoffs_config(config)
     return config
 
 

--- a/docs/eod-consolidation.md
+++ b/docs/eod-consolidation.md
@@ -58,6 +58,8 @@ Five sequential steps. Unlike morning assembly, these are not checkpointed -- th
 5. Idempotent within a session: re-running EOD overwrites this session's sub-sections only.
 6. On success, set `eod_handoff_written: true` in session state (a separate checkpoint from `eod_posted`, which tracks Linear posting).
 
+**Stale-session recovery uses the same path.** When `/start` finds a session with `eod_posted: false` from an earlier date, it backfills a handoff at `~/.workplanner/profiles/<name>/handoffs/{stale_date}.md` using a distinct session-id of the form `stale-recovery-{stale_date}`. The next morning's `/start` Step 0.25 reads the backfilled handoff exactly as it would a normal `/eod`-written one — there is no second mechanism or separate path. See `skills/start/SKILL.md` → "Stale Session Handler".
+
 ## Step 5: Carryover & Close
 
 1. Extract all tasks with status `deferred` or `blocked` from the session.

--- a/docs/state-schema.md
+++ b/docs/state-schema.md
@@ -232,6 +232,10 @@ python3 bin/handoff.py path [--date YYYY-MM-DD]    # prints the resolved path
 
 `write` is idempotent within a session-id: re-running overwrites that session's sub-sections only. Other sessions' sub-sections and unrecognised `## ...` sections (e.g., human free-text additions) are preserved verbatim.
 
+### Stale-session recovery
+
+When `/start` finds a stale session (`current-session.json` date ≠ today) with `eod_posted: false`, it backfills a handoff for the stale date at the **same path** (`~/.workplanner/profiles/<name>/handoffs/{stale_date}.md`) using a distinct session-id of the form `stale-recovery-{stale_date}`. The next morning's `/start` Step 0.25 reads this file the same way it reads a normal-path handoff — aggregation across sub-sections is session-id-agnostic. See `skills/start/SKILL.md` → "Stale Session Handler".
+
 ---
 
 ## Briefings
@@ -402,3 +406,19 @@ wpl decision explain <key>
 ```
 
 `wpl config set` always creates a corresponding decision log entry.
+
+---
+
+## Deprecated
+
+### `config.handoffs.*` (removed in effect as of issue #13)
+
+The following keys are no longer read or honoured by any skill or CLI:
+
+- `config.handoffs.dir`
+- `config.handoffs.filename_pattern`
+- `config.handoffs.carryover_from_handoff`
+
+They previously configured a user-owned ad-hoc handoff file used only by `/start`'s stale-session handler. Handoffs now live exclusively at `~/.workplanner/profiles/<name>/handoffs/YYYY-MM-DD.md` and are managed by `bin/handoff.py` (see **Handoff docs** above). Stale-session recovery writes to the same path, so there is no longer a second mechanism to configure.
+
+If any of these keys is present in a profile's `config.json`, `load_config()` emits a one-line deprecation warning on stderr (at most once per process). The keys themselves are left untouched — remove them from `config.json` when convenient to silence the warning.

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -215,29 +215,56 @@ Confirm: "Config saved. Run `/workplanner:start` again to begin your day."
 
 Triggered when `current-session.json` exists but `date` ≠ today.
 
-1. Read the stale session
-2. If `eod_posted: false` — resolve the missed EOD before proceeding. Branch on `config.handoffs`:
+1. Read the stale session.
 
-   **(a) If `config.handoffs.dir` is set** (local-handoff mode — use this when the EOD artifact is a file rather than an external post):
-   - Target path: `{config.handoffs.dir}/{stale_session.date}.md` (filename resolved via `config.handoffs.filename_pattern`, default `{date}.md`).
-   - If the file is **missing**: draft a handoff from the stale session (done / deferred / blocked summary, notes, open threads, any scope decisions captured in task notes) and write it atomically. No prompt — the file IS the EOD artifact. Augment with Linear `completedAt` / recent-updates for the session's date window and any relevant repo state (new directories, uncommitted files) when the session JSON alone is thin. Log: "Backfilled handoff: {path}".
-   - If the file is **present**: log "Handoff already written for {date}" and continue.
-   - **If `config.handoffs.carryover_from_handoff` is true** (default when `handoffs.dir` is set): the handoff file is authoritative for carryover framing. Read it and let its "Deferred" / "Deferred → tomorrow" section override stale-session task titles and scope. This prevents stale framings from persisting across multiple missed EODs — a scope pivot captured in the handoff file propagates forward even if the session JSON didn't update.
+2. **If `eod_posted: false` — backfill a local handoff for the stale date.**
 
-   **(b) Otherwise** (external-posting mode, e.g., Linear):
-   - Show yesterday's task summary: done count, deferred/blocked count, total
-   - Draft a Linear update for yesterday (same format as `/eod` Step 2)
+   The handoff path is workplanner-owned: `~/.workplanner/profiles/<resolved-name>/handoffs/{stale_session.date}.md`. Check whether this session's backfill contribution already exists. Resolve the path and inspect it via `bin/handoff.py`:
+
+   ```bash
+   STALE_DATE="<stale_session.date>"
+   python3 "${CLAUDE_PLUGIN_ROOT}/bin/handoff.py" read --date "$STALE_DATE"
+   ```
+
+   The read output is a JSON blob with `sections` keyed by section name → session-id → body. Look for a sub-section whose session-id starts with `stale-recovery-` under any section (most commonly `Session trajectory` or `Deferred with reasons`).
+
+   - **If a `stale-recovery-*` sub-section is already present for this date:** log "Handoff already written for {stale_session.date}" and continue to step 3. This makes re-running `/start` on the same stale state idempotent — we do not rewrite an already-backfilled handoff.
+   - **Otherwise:** draft a structured handoff from the stale session and write it via `handoff.py write` with a session-id that is visibly distinct from normal-path IDs:
+     ```bash
+     python3 "${CLAUDE_PLUGIN_ROOT}/bin/handoff.py" write \
+       --session-id "stale-recovery-$STALE_DATE" \
+       --date "$STALE_DATE" \
+       --trajectory "<done / deferred / blocked summary + notes + scope decisions>" \
+       --deferred-json '[{"title":"...","uid":"...","reason":"..."}]' \
+       --open-questions "<open threads noted in the session>" \
+       --context "<any pointers for today that the stale session implies>"
+     ```
+     Draft each section from the stale session JSON (done / deferred / blocked counts + titles, any `defer_reason`s, task notes, scope decisions). When the session JSON alone is thin, augment with:
+     - Linear `completedAt` / recent-updates for the session's date window (for tasks that moved state after the session last wrote).
+     - Relevant repo state — new directories, uncommitted files — if a task in the stale session was clearly mid-work.
+
+     Log: "Backfilled handoff: {path}".
+
+   No prompt. The backfill is silent recovery — the file IS the handoff artifact, and Step 0.25 below will read it the same way it reads a normal-path handoff written by yesterday's `/eod`.
+
+3. **External posting (Linear) — optional, orthogonal to the local handoff.**
+
+   Posting a retroactive daily update to Linear is a separate decision from writing the local handoff. Offer it only if the user has Linear integration wired (i.e., Linear MCP is up and `personal_sub_issue` is set on the stale session or resolvable via `config.weekly_focus`):
+
+   - Draft a Linear update for the stale date in the `/eod` Step 2 format.
    - Ask: "Post yesterday's update to your weekly check-in? [Post / Skip]"
-   - If "Post": use Linear MCP `save_comment` on yesterday's `personal_sub_issue`. Note success.
-   - If "Skip": note "Skipped retroactive EOD" and continue.
+   - On Post: use Linear MCP `save_comment` on the stale session's `personal_sub_issue`. Note success.
+   - On Skip: note "Skipped retroactive Linear post" and continue.
 
-   Why this exists: missed EODs otherwise cause stale task framings to carry forward unchanged for multiple days. The handoff file — when used — captures scope pivots, decisions, and context that session JSON alone cannot reconstruct the morning after.
+   If Linear is not configured or not reachable, skip this step silently — the local handoff from step 2 is sufficient for recovery.
 
-3. Extract `deferred` and `blocked` tasks as carryover candidates (from the handoff file when in local-handoff mode, otherwise from session JSON)
-4. Archive: move session to `~/.workplanner/profiles/active/session/agendas/archive/{date}.json`
-5. Archive the agenda markdown too if it exists
-6. Compute `sweep_since` from the stale session's `eod_target` on its `date`
-7. Proceed to Morning Assembly with carryover list and `sweep_since`
+4. Extract `deferred` and `blocked` tasks as carryover candidates. Prefer the handoff file (via `handoff.py read`) over the raw session JSON when both are available — a scope pivot captured in the handoff overrides the stale session's original task titles and reasons.
+5. Archive: move the session to `~/.workplanner/profiles/active/session/agendas/archive/{date}.json`.
+6. Archive the agenda markdown too if it exists.
+7. Compute `sweep_since` from the stale session's `eod_target` on its `date`.
+8. Proceed to Morning Assembly with carryover list and `sweep_since`.
+
+Why this exists: missed EODs otherwise cause stale task framings to carry forward unchanged for multiple days. The backfilled handoff captures scope pivots, decisions, and context that session JSON alone cannot reconstruct the morning after — and because it lands at the same path as a normal-path handoff, Step 0.25 finds it the next morning without any special-case logic.
 
 ## Morning Assembly
 


### PR DESCRIPTION
Closes #13.

## Summary

Two overlapping handoff mechanisms previously coexisted:

1. **Pre-existing (`config.handoffs.dir`)** — used by `/start`'s stale-session handler to backfill a handoff file when the user missed `/eod` yesterday. User-configurable path, ad-hoc markdown format.
2. **Stream B (`bin/handoff.py`)** — used by `/eod` (normal path) to write a structured handoff at `~/.workplanner/profiles/<name>/handoffs/{date}.md` and read by `/start` Step 0.25 next morning.

Both were "yesterday's handoff for today's `/start` to consume," but they wrote to different paths in different formats, so the normal-path reader (Step 0.25) couldn't find backfilled handoffs. Missed-EOD days effectively had no working handoff.

This PR collapses to the Stream B mechanism. The stale-session handler now writes via `bin/handoff.py` at the workplanner-owned path, using a distinct session-id (`stale-recovery-{date}`) so the backfill is visible in the file. Step 0.25 finds it on day+1 with zero new code — `handoff.py read` aggregates across sub-sections without caring about session IDs.

`config.handoffs.dir`, `config.handoffs.filename_pattern`, and `config.handoffs.carryover_from_handoff` are deprecated. A one-line stderr warning fires at most once per process via a module-level flag in `load_config()`. The user's `config.json` is left untouched — they remove the keys on their own schedule.

## Changes

- `bin/transition.py` — `load_config()` emits a deprecation warning for any of the three legacy `config.handoffs.*` keys, guarded by a module-level once-per-process flag.
- `skills/start/SKILL.md` — "Stale Session Handler" rewritten:
  - Backfill now uses `handoff.py write` with session-id `stale-recovery-{date}`.
  - Idempotence check: read the handoff first; if a `stale-recovery-*` sub-section is already present for the date, log and continue.
  - External Linear posting is no longer gated on whether local handoff is configured — it's an orthogonal optional step gated on Linear MCP availability and a resolvable `personal_sub_issue`.
  - The old (a)/(b) fork is gone.
- `docs/state-schema.md` — new "Stale-session recovery" note under Handoff docs; new "Deprecated" section at the bottom documenting `config.handoffs.*`.
- `docs/eod-consolidation.md` — note that stale-session recovery writes to the same handoff path as `/eod` Step 4.
- `CHANGELOG.md` — Unreleased section describing the consolidation and the deprecation.

`resolve_profile_root()` / `resolve_paths()` untouched (issue #10 lane).

## Verification (all six pass under `WPL_ROOT=/tmp/wpl-issue13-test`)

- **V1** — Stale session with `eod_posted: false`; `handoff.py write` produces a structured file at the workplanner-owned path with `stale-recovery-{date}` session-id, including trajectory / deferred-with-reasons / open-questions / context sections. Sample output in session transcript.
- **V2** — Re-run: the detection check (`any(sid.startswith('stale-recovery-') for ...)`) returns True → handler logs "Handoff already written" and skips. Additionally verified that calling `handoff.py write` with the identical session-id produces a byte-identical file (MD5 match).
- **V3** — Next morning: `handoff.py read --date {stale_date}` returns `exists=True`, parses deferred items with reasons, surfaces the novel `stale-recovery-*` session-id in the per-item `session` field. No changes needed to Step 0.25.
- **V4** — `wpl status` against a profile with all three deprecated keys: stderr shows three one-line warnings (one per key), each pointing at #13, config.json byte-identical before/after.
- **V5** — Three consecutive `load_config()` calls in one Python process: warning fires only on call 1; calls 2 and 3 are silent.
- **V6** — `wpl status` against a profile with no `config.handoffs.*`: no warning on stderr.

## Test plan

- [x] V1 — stale backfill writes to the workplanner-owned path
- [x] V2 — re-run is idempotent (detection + same-session-id re-write)
- [x] V3 — next-day `/start` Step 0.25 reads the backfilled handoff and exposes deferred+reasons
- [x] V4 — deprecation warning fires on stderr, config.json untouched
- [x] V5 — once-per-process flag works
- [x] V6 — clean config produces no warning

## Interaction with issue #10

Does not touch `resolve_profile_root()`, `resolve_paths()`, or profile-selection logic. `bin/handoff.py` already uses `resolve_paths().PROFILE_NAME` / `PROFILE_ROOT`, which will return the path-resolved profile correctly after #10 lands. Any rebase conflicts should be confined to skills/docs.