### PR TITLE
Propagate path-based profile resolution to all callers (fixes #16)

### DIFF
--- a/bin/handoff.py
+++ b/bin/handoff.py
@@ -47,6 +47,7 @@ from pathlib import Path
 # Import minimally from transition.py (same dir) so we share profile
 # resolution and timezone logic. Avoid importing anything that mutates state.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import transition  # noqa: E402
 from transition import (  # noqa: E402
     resolve_paths,
     load_config,
@@ -417,6 +418,19 @@ def main():
         prog="handoff.py",
         description="workplanner local handoff doc read/write.",
     )
+    # Mirror transition.py's top-level --profile so skills invoking this
+    # script directly (as a subprocess, not via `wpl`) can forward the
+    # parent's resolved profile. When absent, we fall back to the usual
+    # precedence chain ($WPL_PROFILE env → cwd-based match → fallback).
+    parser.add_argument(
+        "--profile",
+        dest="profile_override",
+        type=str,
+        default=None,
+        help="Override profile resolution for this invocation. Matches "
+             "`wpl --profile NAME`. When absent, $WPL_PROFILE and "
+             "path-based resolution apply.",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     w = sub.add_parser("write", help="Write or update today's handoff for a session.")
@@ -438,6 +452,11 @@ def main():
     p.set_defaults(func=_cmd_path)
 
     args = parser.parse_args()
+    # Propagate --profile into transition.py's module-level override so
+    # resolve_paths() picks it up. Env var ($WPL_PROFILE) already works
+    # for free via the import-time initialisation there.
+    if getattr(args, "profile_override", None):
+        transition.PROFILE_OVERRIDE = args.profile_override
     args.func(args)
 
 

--- a/bin/render_dashboard.py
+++ b/bin/render_dashboard.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Render the workplanner dashboard from current-session.json.
 
-Reads ~/.workplanner/profiles/active/session/current-session.json and
-~/.workplanner/profiles/active/config.json, writes
-~/.workplanner/profiles/active/session/dashboard-view.txt (atomic: .tmp then mv).
+Resolves the target profile using the same precedence chain as
+transition.py (CLI flag / $WPL_PROFILE / cwd-based match), falling back
+to the legacy ``active`` symlink only for manual invocations from a
+path that no profile claims. Writes dashboard-view.txt (atomic: .tmp
+then mv) under the resolved profile root.
 
 Python 3.9+ stdlib only.
 """
@@ -20,13 +22,74 @@ from pathlib import Path
 WPL_ROOT = Path(os.environ["WPL_ROOT"]) if os.environ.get("WPL_ROOT") else Path.home() / ".workplanner"
 
 
-def resolve_active_profile():
+# Import profile resolution from transition.py so render_dashboard.py honours
+# the same precedence chain (CLI flag / $WPL_PROFILE / cwd-based match) rather
+# than blindly following the `active` symlink. This is the split-brain fix
+# from issue #16: the parent `wpl` invocation may have resolved profile A via
+# cwd, but if we read `active` here we render dashboard for profile B.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from transition import (  # noqa: E402
+        resolve_profile_root as _transition_resolve_profile_root,
+        _find_profile_by_name,
+        _resolve_by_cwd,
+        _iter_profile_dirs,
+        _profile_workspaces,
+        _normalize_path,
+    )
+    _HAS_TRANSITION = True
+except ImportError:
+    _HAS_TRANSITION = False
+
+
+def _active_symlink_fallback():
+    """Last-resort: the `active` symlink. Used only when path-based resolution
+    fails and no override is in scope. Preserves backward-compat with manual
+    invocations outside any declared workspace."""
     active = WPL_ROOT / "profiles" / "active"
     if active.is_symlink() and active.resolve().is_dir():
         return active.resolve()
     if active.is_dir() and not active.is_symlink():
         return active
     return None
+
+
+def resolve_active_profile():
+    """Resolve the target profile, matching transition.py's precedence.
+
+    Order:
+      1. ``$WPL_PROFILE`` env var (set by ``transition.py::render()`` before
+         spawning us as a subprocess, or set by the user for their shell).
+      2. Path-based match against each profile's declared ``workspaces``.
+      3. Single-profile-without-workspaces fallback.
+      4. Legacy ``active`` symlink — kept so manual invocations from an
+         unassociated cwd don't break.
+    """
+    # (1) env var override — parent `wpl` invocation threads its resolved
+    #     profile name through to us this way.
+    override = os.environ.get("WPL_PROFILE", "").strip() or None
+    if override and _HAS_TRANSITION:
+        target = _find_profile_by_name(override)
+        if target is not None:
+            return target
+        # Fall through: a bad override name shouldn't silently fall through
+        # to the wrong profile — but we also don't want to crash the render,
+        # which is called as a side-effect of every mutation. Let the next
+        # tier handle it; worst case we render the legacy active.
+
+    # (2) cwd-based path match
+    if _HAS_TRANSITION:
+        matched, _ws = _resolve_by_cwd()
+        if matched is not None:
+            return matched
+
+        # (3) single-profile fallback (mirror transition.py)
+        all_profiles = list(_iter_profile_dirs())
+        if len(all_profiles) == 1 and not _profile_workspaces(all_profiles[0]):
+            return all_profiles[0]
+
+    # (4) legacy symlink fallback
+    return _active_symlink_fallback()
 
 
 def get_paths():
@@ -522,11 +585,13 @@ def render(session, config=None, idle_periods=None):
         header_date = date_str
 
     now_clock = datetime.now().strftime("%H:%M")
-    # Append active profile name if available
+    # Append resolved profile name to the header. Uses the same resolver
+    # the rest of this module uses (not the `active` symlink) so the
+    # header reflects whichever profile's state we actually rendered.
     profile_name = ""
-    active_link = WPL_ROOT / "profiles" / "active"
-    if active_link.is_symlink() and active_link.resolve().is_dir():
-        profile_name = f" [{active_link.resolve().name}]"
+    resolved = resolve_active_profile()
+    if resolved is not None:
+        profile_name = f" [{resolved.name}]"
     header = f" WORKPLAN  {header_date} \u2014 {week}{profile_name}"
     cols = int(os.environ.get("COLUMNS", 0)) or shutil.get_terminal_size((50, 24)).columns
     pad = max(0, cols - len(header) - len(now_clock))

--- a/bin/session-hook.sh
+++ b/bin/session-hook.sh
@@ -1,9 +1,28 @@
 #!/bin/bash
 # Workplanner session hook — injects active workplan context into any Claude Code session.
 # Registered automatically via plugin.json hooks when the plugin is enabled.
+#
+# Profile resolution: this hook runs at SessionStart with no active `wpl`
+# invocation, so we defer to `wpl` itself (which does path-based cwd
+# resolution). This fixes the split-brain described in issue #16: the
+# hook's cwd is the session's cwd, which is what path-based resolution
+# keys off anyway, so the right profile is selected automatically. The
+# hardcoded `profiles/active/...` path is gone.
 
-SESSION="$HOME/.workplanner/profiles/active/session/current-session.json"
+WPL_BIN="${WPL_BIN:-$HOME/.workplanner/bin/wpl}"
+if [ ! -x "$WPL_BIN" ]; then
+    WPL_BIN=$(command -v wpl 2>/dev/null || true)
+fi
+[ -n "${WPL_BIN:-}" ] && [ -x "$WPL_BIN" ] || exit 0
 
+# Resolve the profile root once via `wpl`. If resolution fails (no profile
+# associated with cwd, no fallback match), silently exit — nothing to inject.
+# `WPL_CHILD=1` suppresses the interactive first-run prompt since there's no
+# TTY here.
+PROFILE_ROOT=$(WPL_CHILD=1 "$WPL_BIN" profile whoami --print-root 2>/dev/null)
+[ -n "$PROFILE_ROOT" ] || exit 0
+
+SESSION="$PROFILE_ROOT/session/current-session.json"
 [ -f "$SESSION" ] || exit 0
 
 # Quick validation — must be today's session and not closed

--- a/bin/test_issue_16.py
+++ b/bin/test_issue_16.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Verification scenarios for issue #16 (path-resolution cleanup).
+
+Runs V1-V6 from the issue against an isolated WPL_ROOT under /tmp.
+Exit 0 on success, 1 on any failed assertion.
+
+Usage:
+    python3 bin/test_issue_16.py
+
+The script spawns the CLIs as subprocesses with a sanitized environment
+so it never touches the user's real ~/.workplanner state.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+BIN_DIR = Path(__file__).resolve().parent
+TRANSITION = BIN_DIR / "transition.py"
+HANDOFF = BIN_DIR / "handoff.py"
+SESSION_HOOK = BIN_DIR / "session-hook.sh"
+WPL_WRAPPER_NAME = "wpl"
+
+
+def _run(cwd, env, *args, script=None, check_exit=None, stdin_input=None):
+    """Invoke a workplanner script as a subprocess.
+    Returns (rc, stdout, stderr)."""
+    full_env = dict(os.environ)
+    for k in [k for k in full_env if k.startswith("WPL_")]:
+        del full_env[k]
+    full_env.update(env)
+    full_env.setdefault("WPL_CHILD", "1")
+    script_path = script or TRANSITION
+    cmd = [sys.executable, str(script_path), *args]
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        env=full_env,
+        capture_output=True,
+        text=True,
+        input=stdin_input,
+    )
+    if check_exit is not None:
+        assert proc.returncode == check_exit, (
+            f"expected exit {check_exit}, got {proc.returncode}\n"
+            f"cmd: {cmd}\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+        )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _init_session(cwd, env, date_str):
+    """Create a minimal current-session.json for the profile resolved at cwd."""
+    # First resolve where we should write.
+    _, root, _ = _run(cwd, env, "profile", "whoami", "--print-root", check_exit=0)
+    root = Path(root.strip())
+    session_path = root / "session" / "current-session.json"
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    session_path.write_text(json.dumps({
+        "date": date_str,
+        "week": "W16",
+        "checkpoint": "initialized",
+        "eod_target": "18:00",
+        "current_task_index": 0,
+        "tasks": [
+            {"uid": "task0001", "title": "First task", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+            {"uid": "task0002", "title": "Second task", "status": "pending",
+             "estimate_min": 15, "source": "manual"},
+        ],
+    }) + "\n")
+    return root, session_path
+
+
+def main():
+    base = tempfile.mkdtemp(prefix="wpl-issue16-")
+    try:
+        wpl_root = Path(base) / ".wpl"
+        ws_a = Path(base) / "ws-a"
+        ws_b = Path(base) / "ws-b"
+        for p in (ws_a, ws_b):
+            p.mkdir(parents=True, exist_ok=True)
+
+        env = {"WPL_ROOT": str(wpl_root)}
+
+        # Bootstrap two profiles pinned to separate workspaces.
+        _run(Path(base), env, "profile", "create", "pa",
+             "--workspace", str(ws_a), check_exit=0)
+        _run(Path(base), env, "profile", "create", "pb",
+             "--workspace", str(ws_b), check_exit=0)
+
+        import datetime as _dt
+        today = _dt.date.today().isoformat()
+
+        root_a, session_a = _init_session(ws_a, env, today)
+        root_b, session_b = _init_session(ws_b, env, today)
+
+        # ── V1: concurrent sessions in different profiles; each dashboard-view
+        # reflects only that profile's state ───────────────────────────────
+        _, _, _ = _run(ws_a, env, "done", check_exit=0)  # marks task0 done in pa
+        # Confirm pa's dashboard exists and mentions the profile.
+        dash_a = root_a / "session" / "dashboard-view.txt"
+        dash_b = root_b / "session" / "dashboard-view.txt"
+        assert dash_a.exists(), "V1: pa dashboard-view.txt not written"
+        assert "[pa]" in dash_a.read_text(), \
+            f"V1: pa dashboard header missing [pa]: {dash_a.read_text()[:200]!r}"
+        # pb's dashboard shouldn't have been touched.
+        assert not dash_b.exists() or "[pa]" not in dash_b.read_text(), \
+            "V1: pb dashboard leaked pa state"
+
+        # Now mutate in pb from its workspace; pa's dashboard should stay.
+        _, _, _ = _run(ws_b, env, "done", check_exit=0)
+        assert dash_b.exists(), "V1: pb dashboard-view.txt not written"
+        assert "[pb]" in dash_b.read_text(), \
+            f"V1: pb dashboard header missing [pb]: {dash_b.read_text()[:200]!r}"
+        assert "[pa]" in dash_a.read_text(), "V1: pa dashboard was overwritten"
+        print("V1: concurrent dashboard isolation [OK]")
+
+        # ── V2: `wpl --profile other done` from profile A's cwd writes
+        # dashboard-view.txt under `other`, not active ─────────────────
+        # Re-init sessions so we can do another mutation.
+        session_a.write_text(json.dumps({
+            "date": today, "week": "W16", "checkpoint": "initialized",
+            "eod_target": "18:00", "current_task_index": 0,
+            "tasks": [
+                {"uid": "task00a1", "title": "PA-task", "status": "in_progress",
+                 "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+            ],
+        }) + "\n")
+        session_b.write_text(json.dumps({
+            "date": today, "week": "W16", "checkpoint": "initialized",
+            "eod_target": "18:00", "current_task_index": 0,
+            "tasks": [
+                {"uid": "task00b1", "title": "PB-task", "status": "in_progress",
+                 "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+            ],
+        }) + "\n")
+        # Snapshot pa's dashboard modification time so we can detect no-touch.
+        dash_a_mtime_before = dash_a.stat().st_mtime if dash_a.exists() else 0
+        # Make sure active symlink points at pa so a buggy render would land there.
+        _, _, _ = _run(Path(base), env, "profile", "switch", "pa", check_exit=0)
+        # From ws_a cwd, run with --profile pb. The render should update pb's
+        # dashboard, not pa's (which is what 'active' points at).
+        _, _, _ = _run(ws_a, env, "--profile", "pb", "done", check_exit=0)
+        dash_b_text = dash_b.read_text()
+        assert "[pb]" in dash_b_text, \
+            f"V2: pb dashboard not updated under --profile pb: {dash_b_text[:200]!r}"
+        # Parse pb's session state — task should be done.
+        sess_b = json.loads(session_b.read_text())
+        assert sess_b["tasks"][0]["status"] == "done", \
+            f"V2: pb task not marked done: {sess_b['tasks'][0]!r}"
+        # pa's session should be untouched.
+        sess_a = json.loads(session_a.read_text())
+        assert sess_a["tasks"][0]["status"] == "in_progress", \
+            f"V2: pa task was touched: {sess_a['tasks'][0]!r}"
+        print("V2: --profile override routes render correctly [OK]")
+
+        # ── V3: dispatch-style cross-profile launch — handoff writes to
+        # the right profile when --profile overrides ──────────────────
+        # Simulate what the dispatch skill does: from cwd=ws_a, with
+        # --profile pb, write a handoff. It should land under pb/handoffs/.
+        rc, out, err = _run(
+            ws_a, env, "--profile", "pb", "write",
+            "--session-id", "s-test-v3",
+            "--trajectory", "V3 trajectory test",
+            script=HANDOFF, check_exit=0,
+        )
+        handoff_path = Path(out.strip())
+        assert str(handoff_path).startswith(str(root_b)), \
+            f"V3: handoff landed outside pb root: {handoff_path} (root_b={root_b})"
+        assert handoff_path.parent.name == "handoffs"
+        # Confirm content made it in.
+        body = handoff_path.read_text()
+        assert "V3 trajectory test" in body, \
+            f"V3: trajectory not in handoff file: {body[:200]!r}"
+        print("V3: dispatch handoff respects --profile [OK]")
+
+        # ── V4: session-hook.sh fired from profile B's workspace injects
+        # status for profile B ─────────────────────────────────────────
+        # The hook uses `wpl`, which we install via ensure_wrapper(). Run
+        # `wpl` once to set up the wrapper, then invoke the hook from ws_b.
+        # We pass the wrapper path via WPL_BIN so it's unambiguous.
+        wpl_bin = wpl_root / "bin" / "wpl"
+        # transition.py::ensure_wrapper writes the wrapper at this path on
+        # any run with WPL_ROOT set.
+        assert wpl_bin.exists(), f"V4: wpl wrapper missing at {wpl_bin}"
+        hook_env = dict(env)
+        hook_env["WPL_BIN"] = str(wpl_bin)
+        proc = subprocess.run(
+            ["bash", str(SESSION_HOOK)],
+            cwd=str(ws_b),
+            env={**os.environ, **hook_env, "WPL_CHILD": "1"},
+            capture_output=True, text=True,
+        )
+        # Hook emits the status text to stdout.
+        output = proc.stdout
+        assert "PB-task" in output or "Active workplan for today" in output, \
+            f"V4: hook output missing pb context: {output!r}"
+        # Must NOT show PA's task title.
+        assert "PA-task" not in output, \
+            f"V4: hook leaked pa context from ws_b cwd: {output!r}"
+        print("V4: session-hook resolves from cwd [OK]")
+
+        # ── V5: `wpl defer --reason ... --format json` includes defer_reason
+        # in the task record ───────────────────────────────────────────
+        # Re-init pa session with a deferrable task. defer count starts at 0
+        # so a single defer doesn't hit threshold (default 3).
+        session_a.write_text(json.dumps({
+            "date": today, "week": "W16", "checkpoint": "initialized",
+            "eod_target": "18:00", "current_task_index": 0,
+            "tasks": [
+                {"uid": "taskV5", "title": "V5-task", "status": "in_progress",
+                 "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+            ],
+        }) + "\n")
+        _, out, _ = _run(ws_a, env, "--format", "json", "defer",
+                         "--reason", "waiting on legal", check_exit=0)
+        payload = json.loads(out)
+        # Look for the affected task with defer_reason.
+        tasks_in_payload = payload.get("session", {}).get("tasks", [])
+        matched = [t for t in tasks_in_payload if t.get("uid") == "taskV5"]
+        assert matched, f"V5: V5-task not in payload: {payload!r}"
+        assert matched[0].get("defer_reason") == "waiting on legal", \
+            f"V5: defer_reason missing or wrong: {matched[0]!r}"
+        print("V5: defer_reason surfaces in --format json [OK]")
+
+        # ── V6: `wpl defer` at reckoning threshold with --format json emits
+        # a structured payload and exits 2 ──────────────────────────────
+        # Pre-load a task at deferral_count = threshold-1 so one more defer
+        # crosses the line.
+        session_a.write_text(json.dumps({
+            "date": today, "week": "W16", "checkpoint": "initialized",
+            "eod_target": "18:00", "current_task_index": 0,
+            "tasks": [
+                {"uid": "taskV6", "title": "V6-task", "status": "in_progress",
+                 "estimate_min": 30, "source": "manual", "started_at": "09:00",
+                 "deferral_count": 2, "defer_reason": "prior reason"},
+            ],
+        }) + "\n")
+        rc, out, err = _run(ws_a, env, "--format", "json", "defer",
+                            "--reason", "still waiting")
+        assert rc == 2, f"V6: expected exit 2 at threshold, got {rc} (stdout={out!r}, stderr={err!r})"
+        # Output should be a single JSON line, not human text.
+        try:
+            rpayload = json.loads(out)
+        except json.JSONDecodeError:
+            raise AssertionError(f"V6: output not JSON: {out!r}")
+        assert rpayload.get("result") == "reckoning-required", \
+            f"V6: wrong result field: {rpayload!r}"
+        assert rpayload.get("action") == "defer"
+        assert rpayload.get("threshold") == 3
+        assert set(rpayload.get("choices", [])) == {"b", "d", "x", "t", "k"}
+        task_record = rpayload.get("task", {})
+        assert task_record.get("uid") == "taskV6"
+        assert task_record.get("deferral_count") == 3
+        assert task_record.get("defer_reason") == "still waiting"
+        print("V6: reckoning threshold honours --format json [OK]")
+
+        print("\nAll V1-V6 scenarios passed.")
+        return 0
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -603,8 +603,21 @@ def save_session(session, undo=True):
 
 
 def render():
-    """Re-render dashboard after mutation."""
-    subprocess.run([sys.executable, str(RENDER)], capture_output=True)
+    """Re-render dashboard after mutation.
+
+    Threads the resolved profile name through to the subprocess via
+    $WPL_PROFILE so render_dashboard.py reads/writes the same profile
+    this invocation mutated — not whatever the `active` symlink happens
+    to point at. Fixes the split-brain described in issue #16.
+    """
+    env = dict(os.environ)
+    try:
+        env["WPL_PROFILE"] = resolve_paths().PROFILE_NAME
+    except SystemExit:
+        # Resolution failed (no profile), let the subprocess inherit
+        # whatever ambient env says; it handles missing-profile itself.
+        pass
+    subprocess.run([sys.executable, str(RENDER)], capture_output=True, env=env)
 
 
 def fail(msg):
@@ -2045,6 +2058,18 @@ def cmd_profile(args):
 
     elif sub == "whoami":
         cwd = _normalize_path(os.getcwd())
+        print_root = getattr(args, "print_root", False)
+        print_name = getattr(args, "print_name", False)
+        # --print-root / --print-name short-circuits to a single line,
+        # suitable for shell substitution. Exits non-zero (via fail())
+        # when resolution fails so callers can guard with `|| exit 0`.
+        if print_root or print_name:
+            target = resolve_profile_root()  # fails loudly if unresolved
+            if print_root:
+                print(str(target))
+            else:
+                print(target.name)
+            return
         override = PROFILE_OVERRIDE or os.environ.get("WPL_PROFILE", "").strip() or None
         if override:
             target = _find_profile_by_name(override)
@@ -2463,9 +2488,17 @@ def build_parser():
         "disassociate", help="Remove a workspace path from a profile")
     p_disassoc.add_argument("name", help="Profile name")
     p_disassoc.add_argument("path", help="Absolute path to remove")
-    profile_sub.add_parser(
+    p_whoami = profile_sub.add_parser(
         "whoami",
         help="Show which profile the current cwd resolves to, and how.")
+    p_whoami.add_argument(
+        "--print-root", action="store_true",
+        help="Print only the resolved profile root path (absolute). "
+             "Useful from shell scripts that need the concrete directory "
+             "without parsing the full whoami output.")
+    p_whoami.add_argument(
+        "--print-name", action="store_true",
+        help="Print only the resolved profile name (no directory).")
     profile_sub.add_parser(
         "validate",
         help="Check for workspace overlaps and missing-workspace warnings.")

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -859,8 +859,13 @@ STATUS_GLYPH = {
 
 
 def _task_record(idx, task):
-    """Compact dict representation of a task for JSON emission."""
-    return {
+    """Compact dict representation of a task for JSON emission.
+
+    ``defer_reason`` is included only when present so non-deferred tasks
+    don't carry a null field (keeps the common case small). This matches
+    how the text-mode one-liner only appends the reason when set.
+    """
+    record = {
         "tid": tid(idx),
         "index": idx,
         "uid": task.get("uid"),
@@ -878,6 +883,10 @@ def _task_record(idx, task):
         "deferral_count": task.get("deferral_count", 0),
         "parent": task.get("parent"),
     }
+    defer_reason = task.get("defer_reason")
+    if defer_reason:
+        record["defer_reason"] = defer_reason
+    return record
 
 
 def session_records(session):
@@ -1160,20 +1169,41 @@ def cmd_defer(args):
                  .get("deferrals", {})
                  .get("reckoning_threshold", 3))
     if count >= threshold:
-        print(f"\u26a0 {tid(idx)} \"{task['title']}\" has been deferred {count} times.")
-        # Surface prior context so the reckoning decision has the "why" in hand.
-        if reason:
-            print(f"  Reason (this defer): {reason}")
-        elif prior_reason:
-            print(f"  Last reason: {prior_reason}")
-        print(f"  What's actually going on?")
-        print(f"  [b] Break it down into smaller tasks")
-        print(f"  [d] Delegate \u2014 reassign or ask for help")
-        print(f"  [x] Drop it \u2014 it's not going to happen")
-        print(f"  [t] Timebox \u2014 schedule a dedicated block (sends to backlog with target date)")
-        print(f"  [k] Keep deferring \u2014 I'll get to it")
-        # Save the incremented count (and reason, if given) but don't change status yet.
+        # Save the incremented count (and reason, if given) *before* emitting
+        # so the payload is consistent with what just landed on disk. Status
+        # is intentionally unchanged: the caller decides via `wpl reckon`.
         save_session(session, undo=False)
+
+        choices = ["b", "d", "x", "t", "k"]
+        prompt_short = "Break down / Delegate / Drop / Timebox / Keep"
+
+        if OUTPUT_FORMAT == "json":
+            # Structured payload for programmatic callers. Exit 2 still
+            # signals "reckoning needed"; the caller now has the full task
+            # record (including defer_reason and deferral_count) to surface
+            # the decision. Fixes the Stream A / Stream B contract gap.
+            payload = {
+                "result": "reckoning-required",
+                "action": "defer",
+                "task": _task_record(idx, task),
+                "threshold": threshold,
+                "choices": choices,
+                "prompt": prompt_short,
+            }
+            print(json.dumps(payload))
+        else:
+            print(f"\u26a0 {tid(idx)} \"{task['title']}\" has been deferred {count} times.")
+            # Surface prior context so the reckoning decision has the "why" in hand.
+            if reason:
+                print(f"  Reason (this defer): {reason}")
+            elif prior_reason:
+                print(f"  Last reason: {prior_reason}")
+            print(f"  What's actually going on?")
+            print(f"  [b] Break it down into smaller tasks")
+            print(f"  [d] Delegate \u2014 reassign or ask for help")
+            print(f"  [x] Drop it \u2014 it's not going to happen")
+            print(f"  [t] Timebox \u2014 schedule a dedicated block (sends to backlog with target date)")
+            print(f"  [k] Keep deferring \u2014 I'll get to it")
         sys.exit(2)  # Signal to calling skill that reckoning is needed
 
     was_current = (idx == session.get("current_task_index"))

--- a/bin/write_event.py
+++ b/bin/write_event.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Append an event to the workplanner events.json for the active profile.
+"""Append an event to the workplanner events.json for the resolved profile.
+
+Profile resolution follows transition.py's precedence: $WPL_PROFILE env
+var → cwd-based match → single-profile fallback → legacy ``active``
+symlink. The legacy symlink is only consulted as a last resort so
+manual invocations from an unassociated cwd still find a target.
 
 Usage:
     python3 write_event.py --id eod_reminder --type info --message "EOD in 30 minutes" --ttl 45
@@ -8,16 +13,60 @@ import argparse, json, os, sys
 from datetime import datetime
 from pathlib import Path
 
-WPL_ROOT = Path.home() / ".workplanner"
+WPL_ROOT = Path(os.environ["WPL_ROOT"]) if os.environ.get("WPL_ROOT") else Path.home() / ".workplanner"
+
+
+# Import profile resolution from transition.py so we honour the same
+# precedence chain (--profile / $WPL_PROFILE / cwd) rather than blindly
+# following the `active` symlink. Fixes the split-brain described in
+# issue #16.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from transition import (  # noqa: E402
+        _find_profile_by_name,
+        _resolve_by_cwd,
+        _iter_profile_dirs,
+        _profile_workspaces,
+    )
+    _HAS_TRANSITION = True
+except ImportError:
+    _HAS_TRANSITION = False
+
+
+def _active_symlink_fallback():
+    """Last-resort: the legacy `active` symlink."""
+    active = WPL_ROOT / "profiles" / "active"
+    if active.is_symlink() and active.resolve().is_dir():
+        return active.resolve()
+    if active.is_dir() and not active.is_symlink():
+        return active
+    return None
+
+
+def _resolve_profile_root():
+    """Same precedence as transition.py::resolve_profile_root but without
+    interactive prompting or hard failure — event writes should be
+    best-effort side-channel operations."""
+    override = os.environ.get("WPL_PROFILE", "").strip() or None
+    if override and _HAS_TRANSITION:
+        target = _find_profile_by_name(override)
+        if target is not None:
+            return target
+    if _HAS_TRANSITION:
+        matched, _ws = _resolve_by_cwd()
+        if matched is not None:
+            return matched
+        all_profiles = list(_iter_profile_dirs())
+        if len(all_profiles) == 1 and not _profile_workspaces(all_profiles[0]):
+            return all_profiles[0]
+    return _active_symlink_fallback()
 
 
 def get_events_path():
-    active = WPL_ROOT / "profiles" / "active"
-    if active.is_symlink() and active.resolve().is_dir():
-        return active.resolve() / "session" / "events.json"
-    if active.is_dir() and not active.is_symlink():
-        return active / "session" / "events.json"
-    return None
+    root = _resolve_profile_root()
+    if root is None:
+        return None
+    return root / "session" / "events.json"
 
 
 def main():

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -75,12 +75,16 @@ wpl profile create NAME [--workspace PATH]    Create a profile, optionally with 
 wpl profile associate NAME PATH               Add a workspace path to an existing profile.
 wpl profile disassociate NAME PATH            Remove a workspace path from a profile.
 wpl profile whoami                            Which profile does cwd resolve to, and how?
+wpl profile whoami --print-root               Print only the resolved profile root path.
+wpl profile whoami --print-name               Print only the resolved profile name.
 wpl profile validate                          Report overlaps and missing-workspace warnings.
 wpl profile migrate                           Interactively associate paths with existing profiles.
 wpl profile switch NAME                       [deprecated] Flip the `active` symlink.
 wpl profile active                            Print the name the `active` symlink points to.
 wpl profile delete NAME                       Delete a profile.
 ```
+
+The `--print-root` / `--print-name` flags are the supported way for shell scripts and skill prose to resolve the concrete profile root/name without parsing the multi-line default output. They honour the same precedence chain (CLI flag > env var > cwd match > single-profile fallback) and exit non-zero if resolution fails.
 
 ## First-run flow for an unassociated cwd
 

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -12,6 +12,19 @@ Hand off an workplanner task to a Claude Code session in a new tmux pane. The se
 **Plugin root:** `${CLAUDE_PLUGIN_ROOT}`
 **Transition CLI:** `${CLAUDE_PLUGIN_ROOT}/bin/transition.py`
 
+## Profile resolution
+
+Dispatch is the highest-stakes skill for cross-profile launches: if the parent `wpl` invocation uses `--profile other` (or `WPL_PROFILE=other`), the dispatched child must land in `other`'s state tree, not whatever the `active` symlink points at.
+
+Resolve **both** `PROFILE_ROOT` and `PROFILE_NAME` at the top of the skill:
+
+```bash
+PROFILE_ROOT=$(wpl profile whoami --print-root)
+PROFILE_NAME=$(wpl profile whoami --print-name)
+```
+
+Use `$PROFILE_ROOT` for file paths. Pass `WPL_PROFILE=$PROFILE_NAME` to the dispatched child so any `wpl` calls it makes inherit the same profile, regardless of the child's cwd (the user may launch in a different workspace tree).
+
 ## Arguments
 
 `$ARGUMENTS`
@@ -71,21 +84,25 @@ Keep it concise — the dispatched session has full filesystem and CLAUDE.md acc
 ### 4. Write prompt to file
 
 ```bash
-mkdir -p ~/.workplanner/profiles/active/handoffs
+mkdir -p "$PROFILE_ROOT/handoffs"
 ```
 
-Write to `~/.workplanner/profiles/active/handoffs/t{index+1}.md`.
+Write to `$PROFILE_ROOT/handoffs/t{index+1}.md`.
 
 ### 5. Launch tmux pane
 
-Determine working directory from `~/.workplanner/profiles/active/config.json` field `working_directory`, or fall back to `$PWD`.
+Determine working directory from `$PROFILE_ROOT/config.json` field `working_directory`, or fall back to `$PWD`.
 
-Write launcher to `/tmp/dispatch-t{index+1}.sh`:
+Write launcher to `/tmp/dispatch-t{index+1}.sh`. The launcher must export `WPL_PROFILE` so the child's `wpl` calls inherit the resolved profile, not whatever the child's cwd resolves to (which may be a different workspace tree):
+
 ```bash
 #!/bin/bash -l
 cd {working_dir}
-claude --permission-mode plan "$(cat ~/.workplanner/profiles/active/handoffs/t{index+1}.md)"
+export WPL_PROFILE={PROFILE_NAME}
+claude --permission-mode plan "$(cat $PROFILE_ROOT/handoffs/t{index+1}.md)"
 ```
+
+Interpolate `{PROFILE_NAME}` and `$PROFILE_ROOT` into the launcher text at write-time — the child shell won't have the parent's `$PROFILE_NAME` variable unless you bake it in.
 
 Launch:
 ```bash

--- a/skills/eod/SKILL.md
+++ b/skills/eod/SKILL.md
@@ -14,6 +14,16 @@ End-of-day wrap-up. Five steps: finalize tasks, draft Linear update, draft Slack
 **Handoff library:** `${CLAUDE_PLUGIN_ROOT}/bin/handoff.py` (read / write / path subcommands)
 **Full procedure:** `${CLAUDE_PLUGIN_ROOT}/docs/eod-consolidation.md`
 
+## Profile resolution
+
+Before any file reads that reference profile state, resolve the concrete profile root **once** and reuse it as `PROFILE_ROOT`. Do not hardcode `~/.workplanner/profiles/active/…` — the `active` symlink is no longer the source of truth (it races under concurrent sessions / `--profile` overrides, per issue #10 and #16):
+
+```bash
+PROFILE_ROOT=$(wpl profile whoami --print-root)
+```
+
+All file paths below should be expressed relative to `$PROFILE_ROOT` (e.g. `$PROFILE_ROOT/session/current-session.json`). Subprocesses launched by this skill (`handoff.py`, `transition.py`) inherit the session's environment and run their own path-based resolution — no extra plumbing needed.
+
 ## Procedure
 
 ### Step 1: Finalize open tasks
@@ -100,7 +110,7 @@ Unlike the Linear/Slack drafts (which are one-shot posts to external systems), t
 
 1. Read final session state:
    ```bash
-   SESSION_JSON=$(cat ~/.workplanner/profiles/active/session/current-session.json)
+   SESSION_JSON=$(cat "$PROFILE_ROOT/session/current-session.json")
    ```
 
    (The skill runs after tasks are finalized, so `deferred`/`blocked` statuses are accurate.)

--- a/skills/freeze/SKILL.md
+++ b/skills/freeze/SKILL.md
@@ -11,6 +11,14 @@ Save and restore Claude Code tmux sessions across reboots.
 
 **Scripts:** `${CLAUDE_PLUGIN_ROOT}/bin/save-sessions.sh`, `${CLAUDE_PLUGIN_ROOT}/bin/restore-sessions.sh`
 
+## Profile resolution
+
+The freeze state file lives in the resolved profile's session directory. Resolve the root once:
+
+```bash
+PROFILE_ROOT=$(wpl profile whoami --print-root)
+```
+
 ## Arguments
 
 `$ARGUMENTS`
@@ -26,7 +34,7 @@ Run from any tmux pane:
 bash "${CLAUDE_PLUGIN_ROOT}/bin/save-sessions.sh"
 ```
 
-Outputs saved session count and contents of `~/.workplanner/profiles/active/session/sessions.json`. Confirm to the user what was saved.
+Outputs saved session count and contents of `$PROFILE_ROOT/session/sessions.json`. Confirm to the user what was saved.
 
 ## Restore (post-reboot)
 
@@ -42,4 +50,4 @@ Opens each saved session in its own tmux pane via `claude --resume <id>`.
 
 - Maps each tmux pane's claude PID to its conversation by correlating process start time with jsonl file birth time in `~/.claude/projects/`
 - Falls back to `--resume` flag in process args for already-resumed sessions
-- State file: `~/.workplanner/profiles/active/session/sessions.json`
+- State file: `$PROFILE_ROOT/session/sessions.json` (per-profile)

--- a/skills/horizon/SKILL.md
+++ b/skills/horizon/SKILL.md
@@ -11,7 +11,14 @@ Review and manage the backlog. The backlog holds work items that don't belong on
 
 **Plugin root:** `${CLAUDE_PLUGIN_ROOT}`
 **Transition CLI:** `${CLAUDE_PLUGIN_ROOT}/bin/transition.py`
-**Backlog file:** `~/.workplanner/profiles/active/backlog.json`
+
+## Profile resolution
+
+Resolve `PROFILE_ROOT` once and reuse. The backlog lives at `$PROFILE_ROOT/backlog.json`, not behind the `active` symlink.
+
+```bash
+PROFILE_ROOT=$(wpl profile whoami --print-root)
+```
 
 ## Arguments
 
@@ -30,7 +37,7 @@ Review and manage the backlog. The backlog holds work items that don't belong on
 python3 "${CLAUDE_PLUGIN_ROOT}/bin/transition.py" backlog --list
 ```
 
-Also read `~/.workplanner/profiles/active/backlog.json` directly for full field access (target_date, not_before, deadline, created_at, tags).
+Also read `$PROFILE_ROOT/backlog.json` directly for full field access (target_date, not_before, deadline, created_at, tags).
 
 ### Step 2: Group items
 
@@ -96,13 +103,13 @@ Allow multiple actions in one response. Process sequentially.
 After the review, update `last_reviewed` in backlog.json:
 
 ```bash
-python3 -c "
+PROFILE_ROOT="$PROFILE_ROOT" python3 -c "
 import json, os
 from datetime import datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-path = Path.home() / '.workplanner' / 'profiles' / 'active' / 'backlog.json'
+path = Path(os.environ['PROFILE_ROOT']) / 'backlog.json'
 with open(path) as f: bl = json.load(f)
 bl['last_reviewed'] = datetime.now().strftime('%Y-%m-%d')
 tmp = str(path) + '.tmp'
@@ -120,7 +127,7 @@ Actions: {N} promoted, {N} rescheduled, {N} dropped
 
 ## Notes
 
-- The backlog is workspace-agnostic — stored at `~/.workplanner/profiles/active/backlog.json`
+- The backlog is profile-scoped — stored at `$PROFILE_ROOT/backlog.json` (each profile has its own)
 - Items enter the backlog via `transition.py backlog "title"`, `transition.py backlog --from t5`, or `transition.py defer --until friday`
 - Morning assembly auto-promotes items whose `target_date` or `deadline` is today or past
 - All mutations go through `transition.py` and are in the undo log

--- a/skills/pickup/SKILL.md
+++ b/skills/pickup/SKILL.md
@@ -12,6 +12,14 @@ Pick up an workplanner task in this Claude session. Collects task context and st
 **Plugin root:** `${CLAUDE_PLUGIN_ROOT}`
 **Transition CLI:** `${CLAUDE_PLUGIN_ROOT}/bin/transition.py`
 
+## Profile resolution
+
+Resolve `PROFILE_ROOT` once and reuse. Do not hardcode `~/.workplanner/profiles/active/…`.
+
+```bash
+PROFILE_ROOT=$(wpl profile whoami --print-root)
+```
+
 ## Arguments
 
 `$ARGUMENTS`
@@ -49,10 +57,10 @@ python3 "${CLAUDE_PLUGIN_ROOT}/bin/transition.py" switch <index>
 
 ### Step 4: Check for existing briefing
 
-Look for a pre-generated briefing in `~/.workplanner/profiles/active/briefings/{session.date}/`:
+Look for a pre-generated briefing in `$PROFILE_ROOT/briefings/{session.date}/`:
 
 ```bash
-ls ~/.workplanner/profiles/active/briefings/{session.date}/ 2>/dev/null | grep "{task.uid}"
+ls "$PROFILE_ROOT/briefings/{session.date}/" 2>/dev/null | grep "{task.uid}"
 ```
 
 A briefing matches if the filename contains the task's UID.

--- a/skills/pre-plan/SKILL.md
+++ b/skills/pre-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pre-plan
-description: "Generate task briefings and surface workplan revisions. Researches tasks in parallel, writes briefings to ~/.workplanner/profiles/active/briefings/{date}/, then presents strategic revisions (decomposition, estimate corrections, duplicates, completed tasks) as a batch for cross-task awareness."
+description: "Generate task briefings and surface workplan revisions. Researches tasks in parallel, writes briefings to the resolved profile's briefings/{date}/ directory, then presents strategic revisions (decomposition, estimate corrections, duplicates, completed tasks) as a batch for cross-task awareness."
 argument-hint: "[all | t3 | search term] — defaults to all pending tasks"
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent, ToolSearch, AskUserQuestion, mcp__linear-server__get_issue, mcp__linear-server__list_comments
 ---
@@ -11,6 +11,16 @@ Generate task briefings ahead of time and surface strategic workplan revisions. 
 
 **Plugin root:** `${CLAUDE_PLUGIN_ROOT}`
 **Transition CLI:** `${CLAUDE_PLUGIN_ROOT}/bin/transition.py`
+
+## Profile resolution
+
+Resolve the concrete profile root **once** at the top of this skill and reuse as `PROFILE_ROOT`. Do not hardcode `~/.workplanner/profiles/active/…` — the `active` symlink is no longer the source of truth.
+
+```bash
+PROFILE_ROOT=$(wpl profile whoami --print-root)
+```
+
+All `briefings/` paths below should be built as `$PROFILE_ROOT/briefings/{session.date}/…`.
 
 ## Arguments
 
@@ -41,7 +51,7 @@ For each selected task, check if a fresh briefing already exists (see Step 3). I
 ### Step 3: Check for existing briefings
 
 ```bash
-ls ~/.workplanner/profiles/active/briefings/{session.date}/ 2>/dev/null
+ls "$PROFILE_ROOT/briefings/{session.date}/" 2>/dev/null
 ```
 
 A briefing is **fresh** if:
@@ -139,12 +149,12 @@ Use `run_in_background: false` for single tasks, `run_in_background: true` for b
 ### Step 6: Write briefings
 
 ```bash
-mkdir -p ~/.workplanner/profiles/active/briefings/{session.date}
+mkdir -p "$PROFILE_ROOT/briefings/{session.date}"
 ```
 
 For each completed agent, extract the `=== BRIEFING ===` section and write to:
 ```
-~/.workplanner/profiles/active/briefings/{session.date}/t{NN}-{uid}-{slug}.md
+$PROFILE_ROOT/briefings/{session.date}/t{NN}-{uid}-{slug}.md
 ```
 
 Where:
@@ -254,7 +264,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/bin/transition.py" switch {original_current_index
 
 ### Step 9: Write index README
 
-Write `~/.workplanner/profiles/active/briefings/{session.date}/README.md`:
+Write `$PROFILE_ROOT/briefings/{session.date}/README.md`:
 
 ```markdown
 # Briefings — {date}
@@ -288,7 +298,7 @@ Session: {session.date}, {session.week}
 ### Step 10: Report
 
 ```
-Pre-planned {N} tasks → ~/.workplanner/profiles/active/briefings/{date}/
+Pre-planned {N} tasks → $PROFILE_ROOT/briefings/{date}/
 
 Briefings:
   t1 — Fix notification loop (execute, ~30m)

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -16,6 +16,16 @@ Start or resume the workday. Routes automatically based on session state.
 **Triage framework:** `${CLAUDE_PLUGIN_ROOT}/docs/triage-framework.md`
 **State schema:** `${CLAUDE_PLUGIN_ROOT}/docs/state-schema.md`
 
+## Profile resolution
+
+Before any file reads / writes that reference profile state, resolve the concrete profile root **once** and reuse it as `PROFILE_ROOT`. Do not hardcode `~/.workplanner/profiles/active/…` — the `active` symlink is no longer the source of truth:
+
+```bash
+PROFILE_ROOT=$(wpl profile whoami --print-root)
+```
+
+All paths in this skill should be expressed relative to `$PROFILE_ROOT`. Subprocesses that this skill launches (`transition.py`, `handoff.py`) do their own path-based resolution automatically.
+
 ## Dashboard Pane (every invocation)
 
 Before routing, ensure the tmux dashboard pane is running. This runs on **every** `/start` invocation — not just during assembly.
@@ -259,7 +269,7 @@ Triggered when `current-session.json` exists but `date` ≠ today.
    If Linear is not configured or not reachable, skip this step silently — the local handoff from step 2 is sufficient for recovery.
 
 4. Extract `deferred` and `blocked` tasks as carryover candidates. Prefer the handoff file (via `handoff.py read`) over the raw session JSON when both are available — a scope pivot captured in the handoff overrides the stale session's original task titles and reasons.
-5. Archive: move the session to `~/.workplanner/profiles/active/session/agendas/archive/{date}.json`.
+5. Archive: move the session to `$PROFILE_ROOT/session/agendas/archive/{date}.json`.
 6. Archive the agenda markdown too if it exists.
 7. Compute `sweep_since` from the stale session's `eod_target` on its `date`.
 8. Proceed to Morning Assembly with carryover list and `sweep_since`.
@@ -335,7 +345,7 @@ This step runs before the inbox sweep so the pre-work task appears at position 0
 
 Execute all 9 runbooks sequentially per `${CLAUDE_PLUGIN_ROOT}/docs/inbox-runbooks.md`:
 
-0. **Backlog sweep** — Read `~/.workplanner/profiles/active/backlog.json`. Auto-promote items to `inbox_items[]`:
+0. **Backlog sweep** — Read `$PROFILE_ROOT/backlog.json`. Auto-promote items to `inbox_items[]`:
    - Items with `target_date <= today` (and `not_before` is null or `<= today`): add with `source: "backlog"`, `priority: "high"`. Remove from backlog.json after promotion.
    - Items with `deadline` and no `target_date`: if deadline is ≤2 days away, add with `source: "backlog"`, `priority: "critical"`, `overdue: true` if past. Remove from backlog.json.
    - Items with `deadline` 3-7 days out: include in "Backlog awareness" footer (see agenda format below), not promoted.


### PR DESCRIPTION
Closes #16.

## Summary

Cleanup pass on top of PRs #11-#15. Four problems, all from the #16 audit:

1. **Programmatic callers still read the `active` symlink.** `render_dashboard.py`, `write_event.py`, and `session-hook.sh` all resolved the profile via the symlink, so a `wpl --profile NAME` invocation would mutate profile NAME but re-render / write events / inject session state against whatever `active` happened to point at. Now they all import the shared resolution helpers from `transition.py` and follow the same precedence (`$WPL_PROFILE` > cwd match > single-profile fallback > legacy symlink fallback). `transition.py::render()` additionally exports `WPL_PROFILE=<resolved>` into the render subprocess so it pins on the parent's resolved name regardless of its own cwd.

2. **`handoff.py` had no `--profile` flag.** Skills invoking it directly as a subprocess couldn't forward the parent's override. Added `--profile NAME` to its argparse; when present it sets `transition.PROFILE_OVERRIDE` before any state reads. `$WPL_PROFILE` and cwd-based resolution continue to work unchanged.

3. **`defer_reason` missing from JSON payload.** `_task_record()` emitted `deferral_count` but dropped the reason, so JSON consumers got a count with no "why". Added `defer_reason` (only when present — keeps the common case small).

4. **`cmd_defer` reckoning-threshold path ignored `--format json`.** When `deferral_count >= threshold`, the code printed plain human text and exited 2 regardless of output format. Now branches on `OUTPUT_FORMAT`: text mode is byte-identical; JSON mode emits a `{result: "reckoning-required", action, task, threshold, choices, prompt}` payload. Exit 2 preserved for existing callers.

## Skills

All seven skills that hardcoded `~/.workplanner/profiles/active/…` paths now resolve `PROFILE_ROOT` (and `PROFILE_NAME` for dispatch) once at the top via `wpl profile whoami --print-root` / `--print-name` — new flags added to the whoami subcommand. Dispatch additionally exports `WPL_PROFILE=$PROFILE_NAME` into the child-pane launcher so dispatched Claude sessions stay pinned to the parent's resolved profile even when the child's cwd sits in a different workspace tree.

## Out of scope (per issue)

- `handoff.py` concurrent-writer race (no `flock`)
- Dispatch handoffs sharing the daily-handoff directory
- `config.handoffs.*` multi-line deprecation warning
- Session-hook cold-start latency

## Verification

New `bin/test_issue_16.py` runs all six V-scenarios against an isolated `$WPL_ROOT`:

- [x] **V1.** Two concurrent sessions (pa, pb) in different workspace trees. Mutation in each. Per-profile `dashboard-view.txt` reflects only that profile's state; no cross-write.
- [x] **V2.** `wpl --profile pb done` from pa's cwd (with `active` → pa): pb's dashboard updated, pa's untouched.
- [x] **V3.** `handoff.py --profile pb write …` from pa's cwd: handoff lands in `pb/handoffs/`, not `pa/handoffs/`.
- [x] **V4.** `session-hook.sh` fired in pb's workspace cwd (with `active` → pa): injected status shows pb's task, not pa's.
- [x] **V5.** `wpl defer --reason "waiting" --format json`: `defer_reason` present on the affected task record.
- [x] **V6.** `wpl defer` at threshold with `--format json`: structured `reckoning-required` JSON payload, exit 2.

Both `bin/test_profile_resolution.py` (existing, T1-T10) and `bin/test_issue_16.py` (new, V1-V6) pass locally.

## Commits

1. `fix(profile): propagate path-based resolution to all callers`
2. `docs(skills): resolve profile root via wpl, not the active symlink`
3. `feat(handoff): add --profile flag matching transition.py`
4. `fix(json): include defer_reason and route reckoning via OUTPUT_FORMAT`
5. `test(issue-16): cover V1-V6 verification scenarios`