### PR TITLE
Cognitive ergonomics cleanup — 9 LLM-facing copy/warning fixes (#18)

### DIFF
--- a/bin/session-hook.sh
+++ b/bin/session-hook.sh
@@ -6,21 +6,41 @@
 # invocation, so we defer to `wpl` itself (which does path-based cwd
 # resolution). This fixes the split-brain described in issue #16: the
 # hook's cwd is the session's cwd, which is what path-based resolution
-# keys off anyway, so the right profile is selected automatically. The
-# hardcoded `profiles/active/...` path is gone.
+# keys off anyway, so the right profile is selected automatically.
+#
+# Graceful fallback: if `wpl` isn't available or its resolver can't
+# claim the cwd, fall back to $HOME/.workplanner/profiles/active so a
+# single-profile setup (or any user whose cwd sits outside every
+# declared workspace) still gets context injected. Hook must fit in the
+# 5s SessionStart timeout — keep every branch lean.
 
 WPL_BIN="${WPL_BIN:-$HOME/.workplanner/bin/wpl}"
 if [ ! -x "$WPL_BIN" ]; then
     WPL_BIN=$(command -v wpl 2>/dev/null || true)
 fi
-[ -n "${WPL_BIN:-}" ] && [ -x "$WPL_BIN" ] || exit 0
 
-# Resolve the profile root once via `wpl`. If resolution fails (no profile
-# associated with cwd, no fallback match), silently exit — nothing to inject.
-# `WPL_CHILD=1` suppresses the interactive first-run prompt since there's no
-# TTY here.
-PROFILE_ROOT=$(WPL_CHILD=1 "$WPL_BIN" profile whoami --print-root 2>/dev/null)
-[ -n "$PROFILE_ROOT" ] || exit 0
+PROFILE_ROOT=""
+if [ -n "${WPL_BIN:-}" ] && [ -x "$WPL_BIN" ]; then
+    # Resolve the profile root once via `wpl`. If resolution fails (no
+    # profile claims this cwd, no single-profile fallback available),
+    # the call exits non-zero and stderr is swallowed. WPL_CHILD=1
+    # suppresses the interactive first-run prompt since there's no TTY
+    # here.
+    PROFILE_ROOT=$(WPL_CHILD=1 "$WPL_BIN" profile whoami --print-root 2>/dev/null)
+fi
+
+# Fallback: the legacy `active` symlink. Preserved so single-profile
+# setups and cwd-outside-any-workspace sessions still get a workplan.
+# Respect $WPL_ROOT so test runs don't leak into the real profile tree.
+if [ -z "$PROFILE_ROOT" ]; then
+    WPL_ROOT_DIR="${WPL_ROOT:-$HOME/.workplanner}"
+    FALLBACK="$WPL_ROOT_DIR/profiles/active"
+    if [ -d "$FALLBACK" ]; then
+        PROFILE_ROOT="$FALLBACK"
+    else
+        exit 0
+    fi
+fi
 
 SESSION="$PROFILE_ROOT/session/current-session.json"
 [ -f "$SESSION" ] || exit 0

--- a/bin/test_issue_18.py
+++ b/bin/test_issue_18.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Verification scenarios for issue #18 (cognitive-ergonomics cleanup).
+
+Runs V1-V9 from the issue against an isolated WPL_ROOT under /tmp.
+Exit 0 on success, 1 on any failed assertion.
+
+Usage:
+    python3 bin/test_issue_18.py
+
+Each V maps to one finding from the convergent 3-pass LLM-as-user
+review; they all exercise error-message / warning / hint changes, not
+semantic behavior. Baseline preserved: commands that used to succeed
+still succeed, commands that used to fail still fail (with better
+messages).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+
+# Use UTC throughout so "today" matches what local_today() returns when
+# the test profile is configured to UTC. Avoids off-by-one-day surprises
+# around midnight in whichever tz the test host is running.
+def _utc_today():
+    return datetime.now(ZoneInfo("UTC")).date()
+
+
+BIN_DIR = Path(__file__).resolve().parent
+TRANSITION = BIN_DIR / "transition.py"
+SESSION_HOOK = BIN_DIR / "session-hook.sh"
+
+
+def _run(cwd, env, *args, check_exit=None, stdin_input=None):
+    """Invoke transition.py as a subprocess. Returns (rc, stdout, stderr)."""
+    full_env = dict(os.environ)
+    for k in [k for k in full_env if k.startswith("WPL_")]:
+        del full_env[k]
+    full_env.update(env)
+    full_env.setdefault("WPL_CHILD", "1")
+    proc = subprocess.run(
+        [sys.executable, str(TRANSITION), *args],
+        cwd=str(cwd),
+        env=full_env,
+        capture_output=True,
+        text=True,
+        input=stdin_input,
+    )
+    if check_exit is not None:
+        assert proc.returncode == check_exit, (
+            f"expected exit {check_exit}, got {proc.returncode}\n"
+            f"args: {args}\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+        )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _write_session(profile_dir, tasks, session_date=None, current_index=None):
+    """Write a current-session.json with the given tasks. Profile's
+    timezone is configured to UTC-equivalent so session_date matching
+    today is deterministic regardless of wall-clock shift."""
+    if session_date is None:
+        session_date = _utc_today().isoformat()
+    session_path = profile_dir / "session" / "current-session.json"
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+    session_path.write_text(json.dumps({
+        "date": session_date,
+        "checkpoint": "initialized",
+        "eod_target": "18:00",
+        "current_task_index": current_index,
+        "tasks": tasks,
+    }) + "\n")
+    return session_path
+
+
+def _configure_tz(profile_dir, tz_name):
+    """Write `timezone` directly into the profile's config.json."""
+    config_path = profile_dir / "config.json"
+    try:
+        cfg = json.loads(config_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        cfg = {}
+    cfg["timezone"] = tz_name
+    config_path.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
+def _clear_tz(profile_dir):
+    """Remove `timezone` from config.json if present (for V9)."""
+    config_path = profile_dir / "config.json"
+    try:
+        cfg = json.loads(config_path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return
+    cfg.pop("timezone", None)
+    config_path.write_text(json.dumps(cfg, indent=2) + "\n")
+
+
+def main():
+    base = tempfile.mkdtemp(prefix="wpl-issue18-")
+    try:
+        wpl_root = Path(base) / ".wpl"
+        ws = Path(base) / "ws"
+        ws_b = Path(base) / "ws-b"
+        for p in (ws, ws_b):
+            p.mkdir(parents=True, exist_ok=True)
+
+        env = {"WPL_ROOT": str(wpl_root)}
+
+        # Bootstrap a profile pinned to ws. Pin timezone to UTC so
+        # session_date = today.isoformat() is accurate in local_today().
+        _run(Path(base), env, "profile", "create", "pa",
+             "--workspace", str(ws), check_exit=0)
+        _run(Path(base), env, "profile", "create", "pb",
+             "--workspace", str(ws_b), check_exit=0)
+        profile_a = wpl_root / "profiles" / "pa"
+        profile_b = wpl_root / "profiles" / "pb"
+        _configure_tz(profile_a, "UTC")
+        _configure_tz(profile_b, "UTC")
+
+        today = _utc_today().isoformat()
+
+        # ── V1: banner distinguishes "all done" from "no active, pending" ──
+        _write_session(profile_a, tasks=[
+            {"uid": "v1-1", "title": "T1", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+            {"uid": "v1-2", "title": "T2", "status": "pending",
+             "estimate_min": 15, "source": "manual"},
+            {"uid": "v1-3", "title": "T3", "status": "pending",
+             "estimate_min": 20, "source": "manual"},
+            {"uid": "v1-4", "title": "T4", "status": "pending",
+             "estimate_min": 10, "source": "manual"},
+        ], current_index=0)
+        _run(ws, env, "switch", "t2", check_exit=0)
+        _run(ws, env, "done", check_exit=0)
+        rc, out, err = _run(ws, env, "status", check_exit=0)
+        header = out.splitlines()[0] if out.splitlines() else ""
+        assert "All tasks complete" not in header, \
+            f"V1: banner lied about completion: {header!r}"
+        assert "No active task" in header and "3 pending" in header, \
+            f"V1: expected 'No active task — 3 pending' in header, got {header!r}"
+        # Finish the plan; now banner should be "All tasks complete".
+        for tid_ in ("t1", "t3", "t4"):
+            _run(ws, env, "switch", tid_, check_exit=0)
+            _run(ws, env, "done", check_exit=0)
+        rc, out, err = _run(ws, env, "status", check_exit=0)
+        header = out.splitlines()[0]
+        assert header.startswith("All tasks complete"), \
+            f"V1: completion banner not restored: {header!r}"
+        print("V1: 'All tasks complete' fires only when done == total [OK]")
+
+        # ── V2: stale-session warning + JSON fields ──────────────────
+        stale_date = (_utc_today() - timedelta(days=3)).isoformat()
+        _write_session(profile_a, tasks=[
+            {"uid": "v2-1", "title": "Stale task", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+        ], session_date=stale_date, current_index=0)
+        rc, out, err = _run(ws, env, "status", check_exit=0)
+        assert "warning: session is from" in err, \
+            f"V2: stale warning missing in stderr: {err!r}"
+        assert stale_date in err, \
+            f"V2: stale date missing from warning: {err!r}"
+        rc, out, err = _run(ws, env, "--format", "json", "status", check_exit=0)
+        payload = json.loads(out)
+        assert payload.get("is_stale") is True, \
+            f"V2: is_stale not true: {payload!r}"
+        assert payload.get("session_date_offset_days") == 3, \
+            f"V2: offset_days != 3: {payload.get('session_date_offset_days')}"
+        print("V2: stale-session warning + JSON fields [OK]")
+
+        # Restore today's session for subsequent tests.
+        _write_session(profile_a, tasks=[
+            {"uid": "v3-1", "title": "T1", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+            {"uid": "v3-2", "title": "T2", "status": "pending",
+             "estimate_min": 15, "source": "manual"},
+        ], current_index=0)
+
+        # ── V3: index-range error uses tN form on tN input ───────────
+        rc, out, err = _run(ws, env, "switch", "t99")
+        assert rc == 1, f"V3: expected rc=1, got {rc}"
+        assert "t99 out of range" in err, \
+            f"V3: expected 't99 out of range', got {err!r}"
+        assert "t1" in err and "t2" in err, \
+            f"V3: expected valid tN range in error, got {err!r}"
+        assert "wpl status" in err, \
+            f"V3: expected 'wpl status' hint, got {err!r}"
+        print("V3: tN input gets tN range in error [OK]")
+
+        # ── V4: missing session file names /workplanner:start ────────
+        session_path = profile_a / "session" / "current-session.json"
+        session_path.unlink()
+        rc, out, err = _run(ws, env, "status")
+        assert rc == 1, f"V4: expected rc=1, got {rc}"
+        assert "/workplanner:start" in err, \
+            f"V4: expected /workplanner:start in error, got {err!r}"
+        rc, out, err = _run(ws, env, "--format", "json", "status")
+        err_payload = json.loads(err)
+        assert err_payload.get("next_action") == "/workplanner:start", \
+            f"V4: JSON error missing next_action: {err_payload!r}"
+        print("V4: missing session error names /workplanner:start [OK]")
+
+        # Restore session.
+        _write_session(profile_a, tasks=[
+            {"uid": "v5-1", "title": "T1", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+            {"uid": "v5-2", "title": "T2", "status": "pending",
+             "estimate_min": 15, "source": "manual"},
+            {"uid": "v5-3", "title": "T3", "status": "pending",
+             "estimate_min": 20, "source": "manual"},
+        ], current_index=0)
+
+        # ── V5: done/blocked/defer t3 redirects to switch pattern ────
+        for verb in ("done", "blocked", "defer"):
+            rc, out, err = _run(ws, env, verb, "t3")
+            assert rc == 1, f"V5 ({verb}): expected rc=1, got {rc}"
+            assert "current task" in err, \
+                f"V5 ({verb}): expected 'current task' in error, got {err!r}"
+            assert f"wpl switch t3 && wpl {verb}" in err, \
+                f"V5 ({verb}): missing switch-pattern redirect: {err!r}"
+        # Backlog should be unpolluted (blocked t3 did not silent-accept).
+        rc, out, _ = _run(ws, env, "backlog", "--list", check_exit=0)
+        assert "t3" not in out, f"V5: blocked t3 polluted backlog: {out!r}"
+        # Sanity: multi-word blocking reason still works.
+        # Need an in_progress task; re-init and switch.
+        _write_session(profile_a, tasks=[
+            {"uid": "v5s-1", "title": "T1", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+        ], current_index=0)
+        rc, out, err = _run(ws, env, "blocked", "on", "code", "review",
+                            check_exit=0)
+        assert "on code review" in (out + err) or "blocked" in out, \
+            f"V5 sanity: multi-word reason: out={out!r} err={err!r}"
+        print("V5: done/blocked/defer tN redirected [OK]")
+
+        # ── V6: session-hook resolves from cwd (fix #6) ──────────────
+        # Write today's session in pb and hit the hook from ws_b.
+        # The hook uses `date +%Y-%m-%d` (local wall clock), so the
+        # session date must match local today — not UTC today — for the
+        # hook's freshness gate to pass. This test doesn't exercise the
+        # UTC-vs-local staleness logic; it just checks profile
+        # resolution.
+        from datetime import date as _local_date
+        _write_session(profile_b, tasks=[
+            {"uid": "v6b-1", "title": "PB-task", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+        ], session_date=_local_date.today().isoformat(), current_index=0)
+        # Ensure wpl wrapper exists — ensure_wrapper() runs on every
+        # transition.py call, so the prior _run calls created it.
+        wpl_bin = wpl_root / "bin" / "wpl"
+        assert wpl_bin.exists(), f"V6: wpl wrapper missing at {wpl_bin}"
+        hook_env = dict(os.environ)
+        for k in [k for k in hook_env if k.startswith("WPL_")]:
+            del hook_env[k]
+        hook_env.update(env)
+        hook_env["WPL_BIN"] = str(wpl_bin)
+        hook_env["WPL_CHILD"] = "1"
+        proc = subprocess.run(
+            ["bash", str(SESSION_HOOK)],
+            cwd=str(ws_b),
+            env=hook_env,
+            capture_output=True,
+            text=True,
+        )
+        assert "PB-task" in proc.stdout, \
+            f"V6: hook output missing pb context: {proc.stdout!r}"
+        print("V6: session-hook resolves from cwd [OK]")
+
+        # ── V7: `wpl backlog list` redirects, doesn't pollute ────────
+        # Reset backlog to empty.
+        (profile_a / "backlog.json").write_text(
+            '{"schema_version": 1, "items": []}\n')
+        for alias in ("list", "show", "ls"):
+            rc, out, err = _run(ws, env, "backlog", alias)
+            assert rc == 1, f"V7 ({alias}): expected rc=1, got {rc}"
+            assert "not a subcommand" in err, \
+                f"V7 ({alias}): missing redirect: {err!r}"
+            assert "--list" in err, \
+                f"V7 ({alias}): missing --list hint: {err!r}"
+        # Backlog must remain empty.
+        bl = json.loads((profile_a / "backlog.json").read_text())
+        assert bl.get("items") == [], f"V7: backlog got polluted: {bl!r}"
+        # Sanity: multi-word title starting with "list" works.
+        rc, out, err = _run(ws, env, "backlog", "list", "of", "onboarding",
+                            "tasks", check_exit=0)
+        bl = json.loads((profile_a / "backlog.json").read_text())
+        assert len(bl.get("items", [])) == 1, \
+            f"V7 sanity: multi-word title not added: {bl!r}"
+        assert bl["items"][0]["title"] == "list of onboarding tasks"
+        print("V7: 'wpl backlog list' redirected, multi-word preserved [OK]")
+
+        # ── V8: --profile breadcrumb + JSON fields ───────────────────
+        _write_session(profile_b, tasks=[
+            {"uid": "v8b-1", "title": "PB-task", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+        ], current_index=0)
+        rc, out, err = _run(ws, env, "--profile", "pb", "status", check_exit=0)
+        first_line = out.splitlines()[0] if out.splitlines() else ""
+        assert "(profile: pb" in first_line and "--profile flag" in first_line, \
+            f"V8: breadcrumb missing/wrong: {first_line!r}"
+        # Env-var form.
+        env_e = dict(env); env_e["WPL_PROFILE"] = "pb"
+        rc, out, err = _run(ws, env_e, "status", check_exit=0)
+        first_line = out.splitlines()[0]
+        assert "$WPL_PROFILE" in first_line, \
+            f"V8: env-var breadcrumb wrong: {first_line!r}"
+        # JSON status carries fields.
+        rc, out, err = _run(ws, env, "--format", "json", "--profile", "pb",
+                            "status", check_exit=0)
+        payload = json.loads(out)
+        assert payload.get("profile_name") == "pb", \
+            f"V8: profile_name wrong: {payload!r}"
+        assert payload.get("resolved_via") == "cli-flag", \
+            f"V8: resolved_via wrong: {payload!r}"
+        # JSON mutation carries fields at top level.
+        rc, out, err = _run(ws, env, "--format", "json", "--profile", "pb",
+                            "switch", "t1", check_exit=0)
+        mut = json.loads(out)
+        assert mut.get("profile_name") == "pb"
+        assert mut.get("resolved_via") == "cli-flag"
+        # No breadcrumb when cwd-match resolution (the common case).
+        rc, out, err = _run(ws, env, "status", check_exit=0)
+        first_line = out.splitlines()[0] if out.splitlines() else ""
+        assert not first_line.startswith("(profile:"), \
+            f"V8: breadcrumb leaked for cwd-match: {first_line!r}"
+        print("V8: --profile breadcrumb and JSON fields [OK]")
+
+        # ── V9: UTC-fallback warning fires once per process ──────────
+        _clear_tz(profile_a)
+        _write_session(profile_a, tasks=[
+            {"uid": "v9-1", "title": "T1", "status": "in_progress",
+             "estimate_min": 30, "source": "manual", "started_at": "09:00"},
+        ], current_index=0)
+        rc, out, err = _run(ws, env, "status", check_exit=0)
+        warn_count = err.count("profile has no 'timezone' set")
+        assert warn_count == 1, \
+            f"V9: expected exactly 1 UTC warning per process, got {warn_count}: {err!r}"
+        # Set timezone; subsequent run is silent.
+        _run(ws, env, "config", "set", "timezone", "UTC",
+             "--rationale", "test", check_exit=0)
+        rc, out, err = _run(ws, env, "status", check_exit=0)
+        assert "profile has no 'timezone'" not in err, \
+            f"V9: warning leaked after tz was set: {err!r}"
+        print("V9: UTC-fallback one-shot warning [OK]")
+
+        print("\nAll V1-V9 scenarios passed.")
+        return 0
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -35,6 +35,45 @@ WPL_ROOT = Path(os.environ["WPL_ROOT"]) if os.environ.get("WPL_ROOT") else Path.
 PROFILE_OVERRIDE = None
 
 
+def resolved_via_source():
+    """Describe how the current process resolved its profile.
+
+    Returns one of: "cli-flag", "env-var", "cwd-match",
+    "single-profile-fallback", or "unresolved". Mirrors the precedence
+    ladder in `resolve_profile_root()` without re-running any side
+    effects. Surfaced in JSON responses (finding 8) and in the --profile
+    breadcrumb printed to stdout when an override is active.
+    """
+    if PROFILE_OVERRIDE:
+        return "cli-flag"
+    if os.environ.get("WPL_PROFILE", "").strip():
+        return "env-var"
+    cwd = _normalize_path(os.getcwd())
+    matched, _ = _resolve_by_cwd(cwd)
+    if matched is not None:
+        return "cwd-match"
+    all_profiles = list(_iter_profile_dirs())
+    if len(all_profiles) == 1 and not _profile_workspaces(all_profiles[0]):
+        return "single-profile-fallback"
+    return "unresolved"
+
+
+def resolved_via_human(source):
+    """Human-readable label for the breadcrumb line.
+
+    Distinct from `resolved_via_source()` because the stdout line uses
+    prose ("via --profile flag") while the JSON field uses a stable
+    machine identifier ("cli-flag").
+    """
+    return {
+        "cli-flag": "via --profile flag",
+        "env-var": "via $WPL_PROFILE",
+        "cwd-match": "via cwd match",
+        "single-profile-fallback": "via single-profile fallback",
+        "unresolved": "unresolved",
+    }.get(source, source)
+
+
 def _normalize_path(raw):
     """Return the absolute, symlink-resolved form of a path string.
 
@@ -1101,6 +1140,16 @@ def _status_payload(session, config=None):
     # load_session() already emitted.
     is_stale, offset_days = session_staleness(session, config)
 
+    # Profile resolution breadcrumb for JSON consumers. An LLM
+    # inspecting profile B with `wpl --profile other status` then
+    # forgetting to re-assert the override on a follow-up mutation
+    # can land writes on the cwd-resolved profile; `profile_name` and
+    # `resolved_via` let the consumer detect that gap programmatically.
+    try:
+        profile_name = resolve_paths().PROFILE_NAME
+    except SystemExit:
+        profile_name = None
+
     return {
         "date": today.isoformat(),
         "session_date": session.get("date"),
@@ -1109,6 +1158,8 @@ def _status_payload(session, config=None):
         "timezone": tz_name,
         "eod_target": eod,
         "checkpoint": session.get("checkpoint"),
+        "profile_name": profile_name,
+        "resolved_via": resolved_via_source(),
         "current_task": current,
         "current_task_index": idx,
         "tasks": session_records(session),
@@ -1134,9 +1185,20 @@ def emit_mutation(action, session, affected=None, config=None, human_line=None):
     in text mode.
     """
     if OUTPUT_FORMAT == "json":
+        try:
+            profile_name = resolve_paths().PROFILE_NAME
+        except SystemExit:
+            profile_name = None
         payload = {
             "result": "ok",
             "action": action,
+            # `profile_name` and `resolved_via` at the top level make
+            # every mutation response self-describing — an LLM chaining
+            # `wpl --profile other status` with a follow-up mutation
+            # can verify the second call landed on the same profile
+            # (finding 8).
+            "profile_name": profile_name,
+            "resolved_via": resolved_via_source(),
             "affected": [
                 {"uid": t.get("uid"), "tid": tid(i), "title": t.get("title")}
                 for (i, t) in (affected or [])
@@ -2938,6 +3000,23 @@ def main():
     # over $WPL_PROFILE env var, which in turn wins over path-based
     # resolution. See resolve_profile_root().
     PROFILE_OVERRIDE = getattr(args, "profile_override", None) or None
+
+    # Profile breadcrumb: when an override is active (CLI flag or env
+    # var), prepend a one-line note to stdout so the LLM sees, in its
+    # own output, that this invocation landed on a non-cwd profile. JSON
+    # mode does the same via `profile_name` / `resolved_via` fields on
+    # every response; no extra stdout line there (would break JSON
+    # parsing). See issue #18, finding 8.
+    if OUTPUT_FORMAT == "text":
+        source = resolved_via_source()
+        if source in ("cli-flag", "env-var"):
+            try:
+                profile_name = resolve_paths().PROFILE_NAME
+            except SystemExit:
+                profile_name = None
+            if profile_name:
+                print(f"(profile: {profile_name} — {resolved_via_human(source)})")
+
     handler = DISPATCH.get(args.command)
     if handler:
         handler(args)

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -722,8 +722,10 @@ def parse_task_target(raw, session):
     """Parse a task target string. Accepts 't3' (display ID), '2' (0-based index),
     or an 8-char uid. Returns (0-based index, task dict)."""
     tasks = session.get("tasks", [])
+    was_tid = False
     if raw.startswith("t") and raw[1:].isdigit():
         target = int(raw[1:]) - 1
+        was_tid = True
     elif raw.isdigit():
         target = int(raw)
     else:
@@ -731,11 +733,28 @@ def parse_task_target(raw, session):
         for i, t in enumerate(tasks):
             if t.get("uid") == raw:
                 return i, t
-        fail(f"Invalid task target: {raw}")
+        fail(f"Invalid task target: {raw}. "
+             f"Use `wpl status` to see valid IDs and UIDs.")
         return None, None  # unreachable
 
     if target < 0 or target >= len(tasks):
-        fail(f"Index {target} out of range (0-{len(tasks) - 1}).")
+        # Echo the input in the user's own vocabulary. If they typed `tN`,
+        # reply with the valid `tN` range; if they typed a bare integer,
+        # reply with the 0-based range they were using.
+        if was_tid:
+            if tasks:
+                valid = f"valid: t1–t{len(tasks)}"
+            else:
+                valid = "no tasks in this session"
+            fail(f"{raw} out of range ({valid}). "
+                 f"Use `wpl status` to see valid IDs and UIDs.")
+        else:
+            if tasks:
+                valid = f"0-{len(tasks) - 1}"
+            else:
+                valid = "no tasks in this session"
+            fail(f"Index {target} out of range ({valid}). "
+                 f"Use `wpl status` to see valid IDs and UIDs.")
     return target, tasks[target]
 
 

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -1628,6 +1628,22 @@ def cmd_backlog(args):
     if args.from_task or args.from_current:
         _backlog_from_session(args)
         return
+    # Foot-gun check: `wpl backlog list` (and common aliases) is a
+    # natural reach for anyone fluent in git/kubectl/linear-cli shape.
+    # The existing routing would silently add a task titled "list"
+    # instead. Redirect only when the *entire* title is the conflicting
+    # word — a multi-word title that starts with "list" (e.g.
+    # "list of onboarding tasks") still passes through. See issue #18,
+    # finding 7.
+    _SUBCOMMAND_ALIASES = {"list", "ls", "show"}
+    title_parts = getattr(args, "title", None) or []
+    if len(title_parts) == 1 and title_parts[0] in _SUBCOMMAND_ALIASES:
+        emit_error(
+            f"'wpl backlog {title_parts[0]}' is not a subcommand; "
+            f"did you mean 'wpl backlog --list'?",
+            suggestion="wpl backlog --list",
+            typed=title_parts[0],
+        )
     # Default: add new item
     _backlog_add(args)
 
@@ -2691,7 +2707,10 @@ def build_parser():
     p_backlog.add_argument("--tag", type=str, action="append", default=None, help="Tag (repeatable).")
     p_backlog.add_argument("--from", dest="from_task", type=str, default=None, help="Move session task to backlog (t3, index, or uid).")
     p_backlog.add_argument("--from-current", action="store_true", help="Move current task to backlog.")
-    p_backlog.add_argument("--list", dest="list_items", action="store_true", help="List backlog items.")
+    p_backlog.add_argument("--list", dest="list_items", action="store_true",
+                           help="List backlog items (use this flag rather than "
+                                "a `list` subcommand — `wpl backlog list` has no "
+                                "subcommand form).")
     p_backlog.add_argument("--promote", type=str, default=None, help="Promote backlog item to today's session (uid).")
     p_backlog.add_argument("--drop", type=str, default=None, help="Remove backlog item (uid).")
     p_backlog.add_argument("--edit", type=str, default=None, help="Edit backlog item fields (uid).")

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -587,9 +587,39 @@ def _config_set_nested(config, key, value):
         d[parts[-1]] = value
 
 
+# Module-level flag so the UTC-fallback warning fires at most once per
+# process — local_today() is called many times per invocation (status
+# header, date fields in payloads, parse_relative_date, decision log,
+# etc.), and one warning is plenty.
+_TZ_FALLBACK_WARNED = False
+
+
 def local_today(config=None):
-    """Return today's date in the configured timezone."""
-    tz_name = (config or {}).get("timezone", "UTC")
+    """Return today's date in the configured timezone.
+
+    Falls back to UTC when no `timezone` key is set on the resolved
+    profile. A one-time stderr warning fires on the first fall-through
+    per process so the LLM / user can see that the `date` field on the
+    header and every JSON payload is UTC-based — not local — and can be
+    off by a day. The default stays UTC: guessing the system timezone
+    heuristically would violate the "context compiler, not decision
+    engine" stance (issue #18, finding 9). The user fixes it
+    deliberately via `wpl config set timezone America/Los_Angeles
+    --rationale "..."`.
+    """
+    global _TZ_FALLBACK_WARNED
+    cfg = config or {}
+    tz_name = cfg.get("timezone")
+    if not tz_name:
+        if not _TZ_FALLBACK_WARNED:
+            _TZ_FALLBACK_WARNED = True
+            print(
+                "warning: profile has no 'timezone' set; using UTC. "
+                "Run 'wpl config set timezone America/Los_Angeles "
+                "--rationale \"...\"' to fix.",
+                file=sys.stderr,
+            )
+        tz_name = "UTC"
     return datetime.now(ZoneInfo(tz_name)).date()
 
 

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -2496,6 +2496,110 @@ def cmd_config(args):
 # ── CLI ──────────────────────────────────────────────────────────────
 
 
+# Verbs that intentionally take no task-target positional: they operate
+# only on the current task (the "two bookends" semantics). When the LLM
+# reaches for `wpl done t3`, we short-circuit argparse with a redirect
+# rather than letting it surface `unrecognized arguments: t3` (done /
+# defer) or silently swallow `t3` as a blocking reason (blocked).
+_CURRENT_TASK_VERBS = {"done", "blocked", "defer"}
+
+
+def _looks_like_task_target(token):
+    """True iff `token` plausibly names a task (tN or 8-char hex uid).
+
+    Deliberately conservative: we only want to redirect the LLM when it
+    clearly mis-aimed a task at a current-only verb. A blocked reason
+    like "blocked on 3 tests" must pass through unchanged — bare
+    integers are NOT flagged.
+    """
+    if not token or token.startswith("-"):
+        return False
+    if token.startswith("t") and len(token) > 1 and token[1:].isdigit():
+        return True
+    # 8-char hex uid — mirrors generate_uid().
+    if len(token) == 8 and all(c in "0123456789abcdef" for c in token):
+        return True
+    return False
+
+
+def _intercept_current_task_verb_misuse(argv):
+    """Redirect `wpl {done,blocked,defer} tN` to the switch-then-verb pattern.
+
+    Walks argv looking for (optional) global flags, then the subcommand.
+    If the subcommand is a current-task verb and any following
+    positional is a task target, emit a structured error and exit.
+    Does not widen the verb surface — this is purely a diagnostic
+    redirect.
+    """
+    i = 0
+    # Skip global flags known to take a value or be a boolean switch.
+    while i < len(argv):
+        tok = argv[i]
+        if tok in ("--format", "--profile"):
+            i += 2
+            continue
+        if tok.startswith("--format=") or tok.startswith("--profile="):
+            i += 1
+            continue
+        if tok in ("-h", "--help"):
+            # Let argparse handle help.
+            return
+        break
+    if i >= len(argv):
+        return
+    verb = argv[i]
+    if verb not in _CURRENT_TASK_VERBS:
+        return
+    # Scan subsequent tokens for a mis-aimed task target. Stop at
+    # recognised verb-local flags so `wpl defer --until friday` isn't
+    # second-guessed and so `wpl blocked --reason ...` style usage
+    # (should it ever land) isn't confused.
+    for token in argv[i + 1:]:
+        if token.startswith("-"):
+            # Any flag ends the scan. Argparse handles flag validation.
+            return
+        if _looks_like_task_target(token):
+            # Text vs JSON: emit_error handles the branching. Exit 1
+            # preserves the "precondition failure" contract for every
+            # wpl error path.
+            # Need OUTPUT_FORMAT set before emit_error is used; peek at
+            # global flags we already skipped.
+            global OUTPUT_FORMAT
+            OUTPUT_FORMAT = _peek_output_format(argv) or "text"
+            # Per-verb phrasing so the "different task" sentence reads
+            # naturally in english. All three map to the same pattern:
+            # switch to the target first, then run the current-task verb.
+            phrasing = {
+                "done": "mark a different task done",
+                "blocked": "mark a different task blocked",
+                "defer": "defer a different task",
+            }[verb]
+            emit_error(
+                f"'{verb}' operates on the current task only (no task target). "
+                f"To {phrasing}, run: wpl switch {token} && wpl {verb}",
+                verb=verb,
+                target=token,
+                suggestion=f"wpl switch {token} && wpl {verb}",
+            )
+    # No mis-aimed target found — let argparse proceed normally.
+    return
+
+
+def _peek_output_format(argv):
+    """Return the --format value from argv, or None. Pre-parse helper.
+
+    Called before argparse runs so errors emitted during the pre-parse
+    hook can honour --format json. Doesn't validate — an invalid value
+    just falls through to the argparse default path.
+    """
+    for i, tok in enumerate(argv):
+        if tok == "--format" and i + 1 < len(argv):
+            return argv[i + 1]
+        if tok.startswith("--format="):
+            return tok.split("=", 1)[1]
+    return None
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         prog="transition.py",
@@ -2792,6 +2896,19 @@ def main():
         print("You can remove it after verifying everything works.")
 
     ensure_wrapper()
+
+    # Pre-parse hook: catch the common "verbs operate on current task only"
+    # footgun before argparse does. `done`, `blocked`, and `defer` take no
+    # task-target positional — they operate on whatever `current_task_index`
+    # points at. Argparse's default message (`unrecognized arguments: t3`,
+    # or silent acceptance for `blocked` where extras become the reason)
+    # doesn't tell the LLM how to recover. Redirect to the documented
+    # two-step pattern instead. Detection is conservative: only `tN`
+    # (digits after t) or an 8-char hex uid is treated as a mis-aimed
+    # task target. Real `blocked` reasons that happen to contain numbers
+    # still pass through untouched. See issue #18, finding 5.
+    _intercept_current_task_verb_misuse(sys.argv[1:])
+
     parser = build_parser()
     args = parser.parse_args()
     # Set module-level output format for this invocation so commands can

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -832,13 +832,34 @@ def status_line(session, config=None):
             f" | ~{fmt_duration(remaining)} left"
             f" | EOD: {eod}"
         )
-    else:
+    # No in_progress task. Distinguish "all done" from "nothing active but
+    # pending remain" so the header doesn't lie after a switch->done
+    # sequence that didn't auto-advance. "All tasks complete" fires only
+    # when every task landed in `done`; anything else (pending, blocked,
+    # deferred left over) gets a "No active task" variant with the
+    # residual pending count.
+    pending_count = sum(1 for t in tasks if t.get("status") == "pending")
+    if total_count and done_count == total_count:
         return (
             f"All tasks complete"
             f" | {date_str}{tz_tag}"
             f" | Done: {done_count}/{total_count}"
             f" | EOD: {eod}"
         )
+    if pending_count:
+        header = f"No active task — {pending_count} pending"
+    elif total_count:
+        # Only blocked/deferred tasks left (nothing pending, not all done).
+        header = "No active task"
+    else:
+        header = "No tasks"
+    return (
+        f"{header}"
+        f" | {date_str}{tz_tag}"
+        f" | Done: {done_count}/{total_count}"
+        f" | ~{fmt_duration(remaining)} left"
+        f" | EOD: {eod}"
+    )
 
 
 # ── Output format / shared formatter ─────────────────────────────────

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -554,17 +554,75 @@ def local_today(config=None):
     return datetime.now(ZoneInfo(tz_name)).date()
 
 
+# Module-level flag so the stale-session warning fires at most once per
+# process, no matter how many times load_session() is called within a
+# single invocation.
+_STALE_SESSION_WARNED = False
+
+
+def session_staleness(session, config=None):
+    """Return (is_stale, offset_days) for a loaded session.
+
+    `offset_days` is positive when the session's date is older than
+    today (the common case), negative if somehow ahead. Missing or
+    unparseable `date` returns (False, 0) — no noise, nothing to warn
+    about. "Stale" means offset_days >= 1.
+    """
+    date_str = (session or {}).get("date")
+    if not date_str:
+        return False, 0
+    try:
+        session_date = datetime.strptime(date_str, "%Y-%m-%d").date()
+    except (ValueError, TypeError):
+        return False, 0
+    today = local_today(config)
+    offset = (today - session_date).days
+    return offset >= 1, offset
+
+
 def load_session():
+    """Load current-session.json for the resolved profile.
+
+    On miss, fails with a recovery hint that names `/workplanner:start`
+    so an LLM hitting a clean profile knows the next step (issue #18).
+    On stale session (date older than today), emits a one-line stderr
+    warning — once per process — but does not block. Callers that want
+    the staleness state programmatically can call `session_staleness()`.
+    """
+    global _STALE_SESSION_WARNED
     paths = resolve_paths()
     try:
         with open(paths.SESSION) as f:
             session = json.load(f)
     except FileNotFoundError:
-        fail("No session file found.")
+        fail(
+            "No session file found. Run /workplanner:start to build today's agenda.",
+            next_action="/workplanner:start",
+        )
     except json.JSONDecodeError as e:
         fail(f"Session JSON parse error: {e}")
     if backfill_uids(session):
         save_session(session, undo=False)
+    # Stale-session warning. Fires once per process; the command still
+    # runs (graceful degradation). Emitted to stderr regardless of
+    # output format — stderr is a separate channel, so JSON consumers
+    # parsing stdout are unaffected. JSON consumers also get `is_stale`
+    # and `session_date_offset_days` on the status payload for
+    # programmatic detection.
+    if not _STALE_SESSION_WARNED:
+        try:
+            is_stale, offset = session_staleness(session, load_config())
+        except SystemExit:
+            is_stale, offset = False, 0
+        if is_stale:
+            _STALE_SESSION_WARNED = True
+            date_str = session.get("date", "(unknown)")
+            noun = "day" if offset == 1 else "days"
+            print(
+                f"warning: session is from {date_str} ({offset} {noun} old). "
+                f"Run /workplanner:start to open today's session.",
+                file=sys.stderr,
+            )
     return session
 
 
@@ -620,10 +678,12 @@ def render():
     subprocess.run([sys.executable, str(RENDER)], capture_output=True, env=env)
 
 
-def fail(msg):
+def fail(msg, **extra):
     # Route through emit_error so JSON mode emits structured errors.
-    # Falls back to the historical "error: ..." line in text mode.
-    emit_error(msg)
+    # Falls back to the historical "error: ..." line in text mode. Extra
+    # kwargs (e.g. next_action=...) are attached to the JSON error object;
+    # they're ignored in text mode so the human-facing line stays clean.
+    emit_error(msg, **extra)
 
 
 def now_hhmm():
@@ -1017,8 +1077,16 @@ def _status_payload(session, config=None):
 
     current = _task_record(idx, task) if task else None
 
+    # Staleness: expose programmatically so JSON consumers can detect a
+    # day-old session without hunting through stderr for the warning
+    # load_session() already emitted.
+    is_stale, offset_days = session_staleness(session, config)
+
     return {
         "date": today.isoformat(),
+        "session_date": session.get("date"),
+        "is_stale": is_stale,
+        "session_date_offset_days": offset_days,
         "timezone": tz_name,
         "eod_target": eod,
         "checkpoint": session.get("checkpoint"),

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -151,3 +151,22 @@ automatically.
   block on stdin.
 - `WPL_ROOT=/some/dir` — redirects the entire state tree. Useful for
   tests and sandbox setups.
+
+## Override breadcrumb
+
+Whenever an override resolves the profile (`--profile` or
+`$WPL_PROFILE`), the CLI surfaces the source so subsequent calls don't
+silently land on the wrong profile.
+
+- **Text mode.** A one-line breadcrumb is prepended to stdout:
+  `(profile: other — via --profile flag)` or
+  `(profile: other — via $WPL_PROFILE)`. Cwd-match resolution stays
+  silent — the common case is unchanged.
+- **JSON mode.** Every status payload and every mutation response
+  carries `profile_name` and `resolved_via` at the top level.
+  `resolved_via` is one of: `cli-flag`, `env-var`, `cwd-match`,
+  `single-profile-fallback`, `unresolved`.
+
+The breadcrumb does not affect behavior — it's a cognitive cue so an
+LLM chaining `wpl --profile other status` with a follow-up mutation
+can verify the second call landed on the same profile.

--- a/docs/task-transitions.md
+++ b/docs/task-transitions.md
@@ -26,9 +26,9 @@ The `wpl` wrapper lives at `~/.workplanner/bin/wpl` and forwards to `bin/transit
 
 | Command | Args | Effect |
 |---------|------|--------|
-| `done` | `[--as "<title>"]` | Mark current task done (records actual_min), advance to next pending |
-| `blocked` | `[reason...]` | Mark current task blocked, advance to next pending |
-| `defer` | — | Mark current task deferred, advance to next pending |
+| `done` | `[--as "<title>"]` | Mark **current task** done (no positional target — see "Current-task verbs" below) |
+| `blocked` | `[reason...]` | Mark **current task** blocked; remaining args become the free-text reason |
+| `defer` | `[--until DATE] [--reason ...]` | Defer **current task**; with `--until` sends to backlog with target date |
 | `add` | `<title> [flags]` | Add a new task (see flags below) |
 | `move` | `<source> --to <dest>` | Reorder a task to a new position |
 | `switch` | `<target> [--no-pause]` | Switch focus to a different task |
@@ -55,6 +55,48 @@ consulted. See `docs/profiles.md` for the full flow and migration notes.
 ### `--as "<title>"` echo check
 
 `done` and `remove` accept an optional `--as "<title>"` argument. When present, the CLI compares the echoed title to the target task's actual title (case-insensitive, whitespace-tolerant). On mismatch, the mutation is refused with an error naming the actual title and UID, and the process exits non-zero. This is a cheap sanity check that catches "wrong-task" mistakes from stale display IDs, and self-documents the LLM's intent in the session transcript. Absent `--as`, behavior is unchanged.
+
+### Current-task verbs vs target verbs
+
+`done`, `blocked`, and `defer` operate **only on the current task** — the one `current_task_index` points at. They take no positional task target. To act on a different task, switch first:
+
+```bash
+wpl switch t3 && wpl done
+```
+
+Typing `wpl done t3` (or `blocked t3` / `defer t3`) is rejected with a structured redirect to the switch-then-verb pattern; `t3` is never silently accepted as a blocked reason.
+
+### Status header — "no active" vs "all complete"
+
+The status header distinguishes three end states:
+
+- **`All tasks complete`** — every task in the plan landed in `done`.
+- **`No active task — N pending`** — no task is `in_progress`, but `N` pending tasks remain. Common after a `switch X && done` sequence that doesn't auto-advance.
+- **`No active task`** — no `in_progress` task and no pending tasks (only blocked/deferred tasks remain).
+
+Only the first means the day is done.
+
+### Stale-session detection
+
+Reading a session whose `date` is older than today emits a one-line stderr warning naming the date and offset, and points at `/workplanner:start`. The command still runs (graceful degradation). JSON consumers can detect staleness programmatically via `is_stale: bool` and `session_date_offset_days: int` on the status payload.
+
+### Profile breadcrumb
+
+When `--profile NAME` or `$WPL_PROFILE` overrides cwd-based resolution, text mode prepends a one-line breadcrumb to stdout:
+
+```
+(profile: other — via --profile flag)
+```
+
+JSON mode carries the same information on every response via `profile_name` and `resolved_via` (one of `cli-flag`, `env-var`, `cwd-match`, `single-profile-fallback`, `unresolved`). Cwd-match resolution emits no breadcrumb (the common case stays quiet).
+
+### Timezone configuration
+
+When the resolved profile has no `timezone` set, `local_today()` falls back to UTC and emits a one-time stderr warning naming the config key. Set the timezone explicitly to silence:
+
+```bash
+wpl config set timezone America/Los_Angeles --rationale "..."
+```
 
 ### `add` flags
 


### PR DESCRIPTION
Closes #18.

Implements the nine convergent findings from the 3-pass LLM-as-user review. None require design changes; all are copy / error-message / warning / one-line resolution-fallback. Behavior is preserved end-to-end — every command that used to succeed still succeeds, every command that used to fail still fails (with a better message).

## Per-fix verification

Each fix is verified by an automated scenario in `bin/test_issue_18.py` (V1-V9), plus the live commands captured below from an isolated `WPL_ROOT=/tmp/wpl-…` run.

### V1 — banner distinguishes "all done" from "no active"
`bin/transition.py::status_line` now branches on `done == total` for the completion banner. After `switch t2 && done` with 3 other pending tasks:
```
No active task — 3 pending | Wed Apr 22 | Done: 1/4 | ~1h left | EOD: 18:00
```
After completing all four:
```
All tasks complete | Wed Apr 22 | Done: 4/4 | EOD: 18:00
```

### V2 — stale-session warning + JSON fields
`load_session()` emits one stderr warning per process; `_status_payload` adds `is_stale` and `session_date_offset_days`.
```
warning: session is from 2026-04-18 (4 days old). Run /workplanner:start to open today's session.
{"is_stale": true, "session_date_offset_days": 4, ...}
```

### V3 — index-range error uses `tN` form on `tN` input
`parse_task_target` echoes the user's vocabulary:
```
error: t99 out of range (valid: t1–t4). Use `wpl status` to see valid IDs and UIDs.
```
Bare-integer input keeps the 0-based form (accurate to what was typed).

### V4 — pre-session error names `/workplanner:start`
```
error: No session file found. Run /workplanner:start to build today's agenda.
```
JSON: `{"error": "...", "next_action": "/workplanner:start"}`

### V5 — done/blocked/defer redirect on mis-aimed target
Pre-parse hook intercepts `wpl {done|blocked|defer} tN` (or 8-char hex uid) before argparse:
```
error: 'done' operates on the current task only (no task target). To mark a different task done, run: wpl switch t3 && wpl done
```
Detection is conservative — `wpl blocked on 3 tests` still records the multi-word reason. Verb surface is NOT widened.

### V6 — session-hook fallback
`bin/session-hook.sh` already path-resolved via `wpl profile whoami --print-root` (PR #17). This pass adds the graceful fallback to `$WPL_ROOT/profiles/active` when resolution yields no match, respecting `$WPL_ROOT` so test runs don't leak into the real profile tree. Latency stays well under the 5s SessionStart timeout (~130ms in measured runs).

### V7 — `wpl backlog list` redirect
`cmd_backlog` rejects `list`/`ls`/`show` as a sole title; multi-word titles starting with "list" still pass through:
```
error: 'wpl backlog list' is not a subcommand; did you mean 'wpl backlog --list'?
```
Backlog stays unpolluted; `wpl backlog list of onboarding tasks` still creates the item.

### V8 — `--profile` breadcrumb
Text mode prepends a one-line breadcrumb when an override is active:
```
(profile: pb — via --profile flag)
```
JSON: every status payload and mutation response carries `profile_name` and `resolved_via` (`cli-flag` / `env-var` / `cwd-match` / `single-profile-fallback` / `unresolved`). Cwd-match resolution stays silent.

### V9 — UTC-fallback warning
`local_today()` warns once per process when no `timezone` is configured:
```
warning: profile has no 'timezone' set; using UTC. Run 'wpl config set timezone America/Los_Angeles --rationale "..."' to fix.
```
Default stays UTC — no heuristic system-tz guessing.

## Test plan

- [x] `python3 bin/test_issue_18.py` — all V1-V9 pass
- [x] `python3 bin/test_profile_resolution.py` — T1-T10 + bonus pass (no regression)
- [x] `python3 bin/test_issue_16.py` — V1-V6 pass (no regression)
- [x] Live verification of each scenario captured above

## Commit map (9 commits)

| Fix | Commit |
|-----|--------|
| #1 banner | `47949af` fix(status) |
| #2 stale | `67a11a5` fix(session) |
| #3 + #4 error wording | `b5b7ef2` fix(errors) |
| #5 redirect | `216755a` fix(cli) |
| #6 hook fallback | `7bad8b0` fix(session-hook) |
| #7 backlog list | `f024915` fix(backlog) |
| #8 breadcrumb | `a689f4f` feat(profile) |
| #9 timezone | `6642ead` fix(timezone) |
| tests + docs | `32cb061` test+docs |

## Files changed

- `bin/transition.py` — fixes 1-5, 7-9 + payload/breadcrumb plumbing
- `bin/session-hook.sh` — fix 6 fallback
- `bin/test_issue_18.py` — V1-V9 verification (new)
- `docs/task-transitions.md` — current-task verbs section, status header rules, stale/breadcrumb/tz notes
- `docs/profiles.md` — override breadcrumb section