### PR TITLE
chore: drop deprecated config.handoffs.* stderr warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
 - **Stale-session recovery unified with normal EOD handoff** (issue #13). `/start`'s stale-session handler now backfills a handoff at `~/.workplanner/profiles/<name>/handoffs/{stale_date}.md` using `bin/handoff.py write` — the same path `/eod` writes to on the normal path. A distinct session-id of the form `stale-recovery-{stale_date}` makes backfills visible in the file. Step 0.25 reads backfilled and normal-path handoffs identically. Re-running `/start` on a still-stale session is idempotent: if a `stale-recovery-*` sub-section is already present for the date, the handler logs "Handoff already written" and continues.
 - **External Linear posting is now orthogonal to local handoff.** The stale-session handler no longer forks between "local-handoff mode" and "external-posting mode". The local handoff is always written; a retroactive Linear post is a separate, optional decision gated on Linear MCP availability and `personal_sub_issue`.
 
-### Deprecated
+### Removed
 
-- `config.handoffs.dir`, `config.handoffs.filename_pattern`, and `config.handoffs.carryover_from_handoff` are deprecated and no longer read by any skill. `load_config()` emits a one-line stderr warning (at most once per process) when any of these keys is present. The keys are left untouched in the user's `config.json` — remove them when convenient to silence the warning.
+- **`config.handoffs.*` deprecation warning** (issue #21). The stderr warning for legacy `config.handoffs.{dir,filename_pattern,carryover_from_handoff}` keys has served its grace period and is removed. `load_config()` is silent on load. Keys present in user config are ignored without comment; remove them at your convenience.
 
 ## 1.0.0-beta.2
 

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -471,42 +471,6 @@ def load_user_json():
         return {}
 
 
-# Module-level flag so the deprecation warning fires at most once per process,
-# regardless of how many times load_config() is called.
-_HANDOFFS_DEPRECATION_WARNED = False
-
-
-def _warn_deprecated_handoffs_config(config):
-    """Emit a one-line stderr warning if legacy config.handoffs.* keys are present.
-
-    Fires at most once per process (module-level flag). The keys themselves are
-    left untouched in config.json — users remove them on their own schedule.
-
-    See https://github.com/melek/workplanner/issues/13.
-    """
-    global _HANDOFFS_DEPRECATION_WARNED
-    if _HANDOFFS_DEPRECATION_WARNED:
-        return
-    handoffs = config.get("handoffs") if isinstance(config, dict) else None
-    if not isinstance(handoffs, dict):
-        return
-    deprecated_keys = ("dir", "carryover_from_handoff", "filename_pattern")
-    present = [k for k in deprecated_keys if k in handoffs]
-    if not present:
-        return
-    _HANDOFFS_DEPRECATION_WARNED = True
-    # One key per message keeps the signal scannable and matches the
-    # "one-line deprecation warning" spec.
-    for k in present:
-        print(
-            f"warning: config.handoffs.{k} is deprecated and has no effect; "
-            f"handoffs now live at ~/.workplanner/profiles/<name>/handoffs/. "
-            f"See https://github.com/melek/workplanner/issues/13. "
-            f"Remove this key from config.json to silence this warning.",
-            file=sys.stderr,
-        )
-
-
 def load_config():
     """Load profile config with user.json fallback for timezone/eod_target."""
     paths = resolve_paths()
@@ -519,7 +483,6 @@ def load_config():
     for key in ("timezone", "eod_target"):
         if key not in config and key in user:
             config[key] = user[key]
-    _warn_deprecated_handoffs_config(config)
     return config
 
 


### PR DESCRIPTION
Closes #21.

Removes the stderr deprecation warning for legacy `config.handoffs.*` keys. The grace period (introduced alongside #13 / #15) has ended; `load_config()` is now silent on load. Keys still present in a user's config.json are ignored without comment.

## Changes

- `bin/transition.py`: delete `_warn_deprecated_handoffs_config()` (lines 479-507), its call site in `load_config()` (line 522), and the `_HANDOFFS_DEPRECATION_WARNED` module flag (lines 474-476).
- `CHANGELOG.md`: replace the `Deprecated` bullet with a `Removed` bullet.

## Tests

All existing tests pass:
- `bin/test_issue_16.py` ✓
- `bin/test_issue_18.py` ✓
- `bin/test_profile_resolution.py` ✓

No new tests added (the removed warning had no coverage and its absence needs no assertion).