### PR TITLE
chore(state): remove vestigial eod_posted + eod_linear_comment_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Removed
 
+- **Vestigial `eod_posted` and `eod_linear_comment_url` session fields** (issue #31). After #23 (private-by-default EOD), nothing in the plugin writes `eod_posted` or `eod_linear_comment_url`. The stale-session trigger now reads `eod_handoff_written` — the canonical, actually-set EOD-completion marker. `eod_handoff_written` is documented as the single source of truth for "did EOD complete." Existing session JSON files with the old fields are ignored; they drop off on the next write.
 - **`config.handoffs.*` deprecation warning** (issue #21). The stderr warning for legacy `config.handoffs.{dir,filename_pattern,carryover_from_handoff}` keys has served its grace period and is removed. `load_config()` is silent on load. Keys present in user config are ignored without comment; remove them at your convenience.
 
 ## 1.0.0-beta.2

--- a/bin/test_eod_flow.py
+++ b/bin/test_eod_flow.py
@@ -97,6 +97,15 @@ def test_start_skill_no_retroactive_post_prompt():
                      "start skill: retroactive-post negation present")
 
 
+def test_start_skill_uses_eod_handoff_written():
+    """Stale-session trigger must check eod_handoff_written, not vestigial eod_posted."""
+    text = _read(START_SKILL)
+    _assert_absent(text, "eod_posted",
+                   "start skill: eod_posted must be gone post #31")
+    _assert_contains(text, "eod_handoff_written",
+                     "start skill: canonical EOD marker present")
+
+
 def test_eod_doc_step_order():
     """docs/eod-consolidation.md mirrors the skill's new order."""
     text = _read(EOD_DOC)
@@ -128,6 +137,7 @@ def main():
         test_eod_skill_close_gate,
         test_eod_skill_conditional_drafts,
         test_start_skill_no_retroactive_post_prompt,
+        test_start_skill_uses_eod_handoff_written,
         test_eod_doc_step_order,
         test_eod_doc_no_auto_post,
     ]

--- a/docs/state-schema.md
+++ b/docs/state-schema.md
@@ -25,9 +25,7 @@ Source of truth for all session state. If the JSON and any derived artifacts (ma
 | `current_task_index` | `integer \| null` | yes | 0-based index of the active task in the `tasks` array, or `null` if no task is active. |
 | `tasks` | `array` | yes | Ordered list of task objects. |
 | `coordination_thread` | `object \| null` | no | Captured Slack coordination thread, if any. |
-| `eod_posted` | `boolean` | yes | Whether the end-of-day summary has been posted (to Linear / external system). |
-| `eod_linear_comment_url` | `string \| null` | yes | URL of the EOD comment on Linear, or `null` if not yet posted. |
-| `eod_handoff_written` | `boolean` | no | Whether this session wrote its contribution to today's local handoff doc (`profiles/<name>/handoffs/YYYY-MM-DD.md`). Distinct from `eod_posted` — handoff-write and Linear-post are separate checkpoints. Default: absent/`false` on older sessions (migration-safe). |
+| `eod_handoff_written` | `boolean` | no | Canonical EOD-completion marker. Set to `true` by `/eod` Step 2 after the local handoff doc is written successfully; session close (Step 4) gates on this being true. Absent or `false` in a past-dated session signals that EOD did not complete and triggers the stale-session handler in `/start`. |
 | `sweep_since` | `string` (ISO 8601) \| null | no | Cutoff timestamp for inbox sweep. Computed from previous session's EOD or yesterday 08:00. |
 | `inbox_items` | `array` | no | Raw captured items from inbox sweep. Cleared after `agenda_built`. See inbox item schema. |
 | `headlines` | `array` of `string` | no | FYI items for agenda header (from digest + low-signal sources). |
@@ -235,7 +233,7 @@ python3 bin/handoff.py path [--date YYYY-MM-DD]    # prints the resolved path
 
 ### Stale-session recovery
 
-When `/start` finds a stale session (`current-session.json` date ≠ today) with `eod_posted: false`, it backfills a handoff for the stale date at the **same path** (`~/.workplanner/profiles/<name>/handoffs/{stale_date}.md`) using a distinct session-id of the form `stale-recovery-{stale_date}`. The next morning's `/start` Step 0.25 reads this file the same way it reads a normal-path handoff — aggregation across sub-sections is session-id-agnostic. See `skills/start/SKILL.md` → "Stale Session Handler".
+When `/start` finds a stale session (`current-session.json` date ≠ today) whose `eod_handoff_written` is absent or `false`, it backfills a handoff for the stale date at the **same path** (`~/.workplanner/profiles/<name>/handoffs/{stale_date}.md`) using a distinct session-id of the form `stale-recovery-{stale_date}`. The next morning's `/start` Step 0.25 reads this file the same way it reads a normal-path handoff — aggregation across sub-sections is session-id-agnostic. See `skills/start/SKILL.md` → "Stale Session Handler".
 
 ---
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -235,7 +235,7 @@ Triggered when `current-session.json` exists but `date` ≠ today.
 
 1. Read the stale session.
 
-2. **If `eod_posted: false` — backfill a local handoff for the stale date.**
+2. **If `eod_handoff_written` is absent or `false` — backfill a local handoff for the stale date.**
 
    The handoff path is workplanner-owned: `~/.workplanner/profiles/<resolved-name>/handoffs/{stale_session.date}.md`. Check whether this session's backfill contribution already exists. Resolve the path and inspect it via `bin/handoff.py`:
 


### PR DESCRIPTION
Closes #31.

After #23 (private-by-default EOD), the plugin no longer auto-posts to Linear or prompts Post/Edit/Skip. As a result, nothing writes `eod_posted` or `eod_linear_comment_url` anywhere — they became dead fields the moment #23 merged.

## Changes

- `docs/state-schema.md`: drop the `eod_posted` and `eod_linear_comment_url` rows. Rewrite the `eod_handoff_written` row as the canonical "did EOD complete" marker, including the stale-session semantics. Update the stale-session-recovery paragraph to reference `eod_handoff_written`.
- `skills/start/SKILL.md:212`: stale-session trigger now checks `eod_handoff_written is absent or false` (was `eod_posted: false`).
- `bin/test_eod_flow.py`: new assertion that `eod_posted` is absent from the start skill and `eod_handoff_written` is referenced.
- `CHANGELOG.md`: Removed entry.

## Not an enum collapse

The original Issue 5 plan was to collapse `eod_posted` + `eod_handoff_written` into an `eod_state` enum. With `eod_posted` already dead, there's nothing to collapse — just deletion. Simpler fix.

## Session migration

Existing session JSON files with the old fields are silently ignored; they drop off on the next write. No explicit migration needed.

## Tests

All pass:
- `bin/test_issue_16.py` ✓
- `bin/test_issue_18.py` ✓
- `bin/test_profile_resolution.py` ✓
- `bin/test_start_prompts.py` ✓
- `bin/test_eod_flow.py` ✓ (8 tests, +1 new)