### PR TITLE
docs: surface sub-task (--parent) feature in skill prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- **Surface the sub-task (`--parent`) feature in skill prose and task-transition docs** (issue #33). The engine has supported `wpl add --parent <id>` (and the dashboard renders parent/child trees) for several versions, but the feature was invisible in `docs/task-transitions.md`, `skills/start/SKILL.md`, `docs/morning-assembly.md`, and `skills/pickup/SKILL.md` — so LLMs defaulted to flat sibling lists and project-scoped work was never grouped. Drift closed: the `add` flags table now lists `--parent`, there's a new "Sub-tasks" section in task-transitions with the CLI pattern and when-to-use guidance, the start-skill task-transition example includes a `--parent` line with a "parent/child for project work" explainer, Step 3 of morning-assembly adds a "Parent/child for project work" paragraph, and pickup notes that a parent's children should be inspected as a group. `bin/test_start_prompts.py` gains four regression assertions so the drift can't silently re-open.
+
 ## 1.0.0-beta.4
 
 Session-tidy release — each change is a small, self-contained PR guided by the plugin's seven methodology principles and the three-layer architecture. Six merged PRs (#22, #24, #26, #28, #30, #32) over issues #21, #23, #25, #27, #29, #31.

--- a/bin/test_start_prompts.py
+++ b/bin/test_start_prompts.py
@@ -19,6 +19,8 @@ REPO = Path(__file__).resolve().parent.parent
 START_SKILL = REPO / "skills" / "start" / "SKILL.md"
 INBOX_RUNBOOKS = REPO / "docs" / "inbox-runbooks.md"
 MORNING_ASSEMBLY = REPO / "docs" / "morning-assembly.md"
+TASK_TRANSITIONS = REPO / "docs" / "task-transitions.md"
+PICKUP_SKILL = REPO / "skills" / "pickup" / "SKILL.md"
 
 
 def _read(path):
@@ -115,6 +117,36 @@ def test_dashboard_pane_never_skips_spawn():
                      "dashboard_pane: never branch language")
 
 
+def test_subtask_feature_surfaced_in_task_transitions():
+    """--parent flag must be documented in docs/task-transitions.md (issue #33)."""
+    text = _read(TASK_TRANSITIONS)
+    _assert_contains(text, "--parent",
+                     "task-transitions: --parent flag in add table")
+    _assert_contains(text, "Sub-tasks",
+                     "task-transitions: Sub-tasks section heading")
+
+
+def test_subtask_feature_surfaced_in_start_skill():
+    """start SKILL must mention --parent in the task-transitions example (issue #33)."""
+    text = _read(START_SKILL)
+    _assert_contains(text, "--parent",
+                     "start skill: --parent in transition example")
+
+
+def test_subtask_feature_surfaced_in_morning_assembly():
+    """morning-assembly.md must mention parent/child in Step 3 (issue #33)."""
+    text = _read(MORNING_ASSEMBLY)
+    _assert_contains(text, "Parent/child for project work",
+                     "morning-assembly: parent/child section")
+
+
+def test_subtask_feature_surfaced_in_pickup():
+    """pickup SKILL must mention parent/children handling (issue #33)."""
+    text = _read(PICKUP_SKILL)
+    _assert_contains(text, "parent",
+                     "pickup skill: parent task handling")
+
+
 def main():
     tests = [
         test_pre_work_no_task_insertion,
@@ -125,6 +157,10 @@ def main():
         test_calendar_fallback_gated_in_assembly_doc,
         test_dashboard_pane_policy_referenced,
         test_dashboard_pane_never_skips_spawn,
+        test_subtask_feature_surfaced_in_task_transitions,
+        test_subtask_feature_surfaced_in_start_skill,
+        test_subtask_feature_surfaced_in_morning_assembly,
+        test_subtask_feature_surfaced_in_pickup,
     ]
     failures = 0
     for t in tests:

--- a/docs/morning-assembly.md
+++ b/docs/morning-assembly.md
@@ -100,6 +100,10 @@ Transform `session.inbox_items[]` into `session.tasks[]`.
 5. **Order** — Carryover → Critical → High (due-today first) → Medium → Focus/check-in
 6. **Insert Time Structure** — Protected blocks + calendar events. Compute budget.
 
+### Parent/child for project work
+
+When several inbox items belong to one project and share a gate (a milestone, a PR checklist, a consolidation day), surface them as a parent with children rather than as flat siblings. Create the parent task first and add the sub-steps with `--parent <id>`; the dashboard renders them as a tree. See `docs/task-transitions.md` → "Sub-tasks" for the CLI pattern. A normal mixed-topic agenda stays flat — parent/child is for the case where the hierarchy is doing real work.
+
 After triage, **clear `session.inbox_items[]`** to keep session JSON lean. The data has been consumed into `session.tasks[]` and `session.headlines[]`.
 
 ---

--- a/docs/task-transitions.md
+++ b/docs/task-transitions.md
@@ -107,10 +107,29 @@ wpl config set timezone America/Los_Angeles --rationale "..."
 | `--done` | false | Mark as already completed |
 | `--started HH:MM` | auto | Start time (used with `--done`) |
 | `--finished HH:MM` | now | Finish time (used with `--done`) |
+| `--parent <id>` | — | Create as a sub-task under the named parent (`t3`, index, or uid). See "Sub-tasks" below. |
 | `--source VAL` | manual | Source tag |
 | `--ref VAL` | — | Issue reference (e.g., `PROJ-123`) |
 | `--url VAL` | — | Issue URL |
 | `--notes VAL` | — | Free-text notes |
+
+### Sub-tasks
+
+Tasks can be nested one level via `--parent`. When the parent rolls up several related sub-steps that share context and a single gate, use this instead of a flat sibling list. The dashboard renders parents with their children as a tree.
+
+```bash
+# Parent: the umbrella task
+wpl add "RSM: M1 consolidation" --est 140 --at top
+
+# Children: each step under the parent (parent is now t1)
+wpl add "Check Paulina's workflow blocker" --est 30 --parent t1
+wpl add "Vendor judge prompt + schema" --est 20 --parent t1
+wpl add "Pull HAPAI candidates into v0.jsonl" --est 45 --parent t1
+```
+
+When to use it: project-scoped work with multiple sub-steps, a shared gate, and enough coherence that the parent is a meaningful unit of progress. When to skip it: a normal day's mixed-topic agenda — flat siblings read better than a tree of unrelated items.
+
+The `parent` field is an integer index into the task array (see `docs/state-schema.md`). There is no re-parent command today; if you need to restructure an existing flat group, remove the siblings and re-add them with `--parent`.
 
 All mutating commands:
 1. Read and validate `current-session.json`

--- a/skills/pickup/SKILL.md
+++ b/skills/pickup/SKILL.md
@@ -49,6 +49,8 @@ Parse the JSON output. If no session exists, stop: "No active session. Run `/wor
 
 If the task is already `done`, `blocked`, or `deferred`, warn and confirm before proceeding.
 
+**If the task is a parent (has children):** the children are related sub-steps that share the parent's gate. Read them alongside the parent and present the whole group in Step 6 rather than picking up the parent in isolation. Children are tasks whose `parent` field points at this task's index; `wpl status` renders them nested below the parent.
+
 ### Step 3: Mark in_progress
 
 ```bash

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -452,12 +452,15 @@ wpl defer
 wpl defer --until friday          # defer to backlog with target date
 wpl add "Review PR #4521" --est 30
 wpl add "1:1 with Ash" --est 30 --at top --done --started 09:00 --finished 09:30
+wpl add "Sub-step" --est 20 --parent t1     # nested under t1; see "Sub-tasks" in docs/task-transitions.md
 wpl move t5 --to t2
 wpl switch t4
 wpl switch t4 --no-pause          # keep previous task in_progress (parallel work)
 wpl backlog "Future task" --est 30 --target next-week
 wpl status
 ```
+
+**Parent/child for project work.** When a task rolls up several related sub-steps that share context and a single gate (an RSM milestone, a PR checklist, an incident response), create a parent and add the sub-steps with `--parent <id>` rather than as flat siblings. The dashboard renders them as a tree. Flat siblings still read better for a normal day's mixed-topic agenda.
 
 **During the day, always use `wpl`** (or `~/.workplanner/bin/wpl`) for task state changes — it handles atomic writes, validation, and re-rendering. During assembly and EOD, write JSON directly with atomic writes (tmp → mv).
 


### PR DESCRIPTION
Closes #33.

The engine has supported `wpl add --parent <id>` and the dashboard has rendered parent/child trees for several versions — but the feature was invisible in the skill prose and task-transition docs. LLMs running `/start`, `/pickup`, or any task-mutation flow defaulted to flat sibling lists because that's what the docs modeled. Project-scoped work never got grouped.

This is a **capability/operation drift** fix: no engine change, no schema change (the `parent` field is already documented at `docs/state-schema.md:88`). Just teaching the LLM that the feature exists.

## Changes

- `docs/task-transitions.md` — `--parent` added to the `add` flags table; new "Sub-tasks" section with CLI pattern, when-to-use / when-not-to-use guidance, and a note on the missing re-parent command.
- `skills/start/SKILL.md` — `--parent` example in the task-transitions snippet; new "Parent/child for project work" paragraph clarifying that flat siblings still win for mixed-topic agendas.
- `docs/morning-assembly.md` — Step 3 gains a "Parent/child for project work" paragraph so agenda-build considers hierarchy when inbox items share a gate.
- `skills/pickup/SKILL.md` — if picking up a parent task, note that the children are related and should be inspected as a group.
- `bin/test_start_prompts.py` — four new content-level regression tests guarding each surface.
- `CHANGELOG.md` — Unreleased entry.

## Tests

All pass:
- `bin/test_issue_16.py` ✓
- `bin/test_issue_18.py` ✓
- `bin/test_profile_resolution.py` ✓
- `bin/test_eod_flow.py` ✓
- `bin/test_start_prompts.py` ✓ (12 tests, +4 new)