### PR TITLE
docs: graceful-degradation misapplication trap + v1.0.0-beta.5

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workplanner",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "repository": "https://github.com/melek/workplanner",
   "description": "Daily work-planning and progress-tracking for Claude Code — morning assembly, task transitions, pre-planning, backlog/horizon, EOD consolidation",
   "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+## 1.0.0-beta.5
+
+Methodology-reach release — four merged PRs (#34, #36/#37/#38, this) across issues #33, #35, #40, focused on closing the gap between the plugin's engine capabilities and the skill prose that teaches them to the LLM.
+
 ### Changed
 
+- **Document the graceful-degradation misapplication trap** (issue #40). A cold-session retest of the methodology reach surfaced one concrete misapplication: principle #7 (Graceful Degradation) was cited in a prioritization audit to justify criticality-based task sequencing. That's a priority-tier argument dressed in principle language. Added a "Not an argument for..." callout to principle #7 in `docs/methodology.md` explicitly naming the criticality-sequencing trap and pointing at `docs/triage-framework.md` as the right surface for that class of question. Single observed trap, single callout; no generalized framework. Follow-up traps get their own one-line callouts as and when cold-session tests surface them. (Issues #39 was filed for a broader "reasoning scaffolds + decision trees + auditor patterns" program but closed as over-scoped — the trust goal is better served by periodic cold-session retests catching drift than by bureaucratizing every EA-shape response.)
 - **Make the EA/PA methodology reach and shape ad-hoc work-shape questions** (issue #35). Two attempts and two verification tests:
   - **Attempt 1 (PR #36):** Pointer added to the plugin's root `CLAUDE.md` on the assumption that plugin CLAUDE.md loads ambiently. Real-session test contradicted that assumption — the session confirmed it had read no plugin documentation.
   - **Attempt 2 (PR #37):** Pointer moved to the SessionStart hook (`bin/session-hook.sh`), which is already proven to reach sessions via its workplan-status output. Retest: the agent did read `docs/methodology.md`, but reasoned in generic PM vocabulary ("critical path", "budget", "risk") without applying any of the seven principles by name.

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -52,6 +52,8 @@ Any data source can fail. Any MCP can be absent. The system always produces *som
 
 **Lineage:** Resilience engineering. For a daily planning tool, "no plan" is worse than "partial plan." The system is designed to be useful even with only a calendar and manual task entry.
 
+**Not an argument for:** sequencing tasks by criticality ("do the load-bearing thing first"). Criticality ordering is a priority-tier decision (see `docs/triage-framework.md`); graceful degradation is specifically about producing partial value when *components fail*, not about which task to do first when all components are working.
+
 ## Neurodivergent Design Rationale
 
 The methodology specifically addresses executive function challenges:


### PR DESCRIPTION
Closes #40. Single callout under principle #7 in docs/methodology.md naming the criticality-sequencing trap observed in the #35 cold-session retest. Version bumped to 1.0.0-beta.5; release promotes today's Unreleased entries (#33, #35, #40) into the beta.5 section.