### PR TITLE
feat(rename): wpl rename + original_title preservation (fixes #42)

### DIFF
--- a/bin/handoff.py
+++ b/bin/handoff.py
@@ -219,18 +219,27 @@ def read_handoff(target_date=None):
             out["sections"][name][sid] = body.rstrip() + "\n"
 
     # Best-effort extraction of deferred items. Pattern per-line:
-    #   - **<title>** (<uid>): <reason>
+    #   - **<title>** [(was: <orig>)] [(<uid>)]: <reason>
     # Everything else is returned as raw text under sections → skills can
     # still display it as-is if the line doesn't match.
     deferred_section = out["sections"].get("Deferred with reasons", {})
-    line_re = re.compile(r"^\s*-\s+\*\*(?P<title>[^*]+)\*\*\s*(?:\(([^)]+)\))?\s*:\s*(?P<reason>.+?)\s*$")
+    # `(was: ...)` allows parens inside via lazy-match + lookahead for the next
+    # delimiter (uid paren or trailing colon). uid paren stays strict (no
+    # nested parens in uids).
+    line_re = re.compile(
+        r"^\s*-\s+\*\*(?P<title>[^*]+)\*\*"
+        r"(?:\s*\(was:\s*(?P<orig>.+?)\)(?=\s*(?:\(|:\s)))?"
+        r"\s*(?:\((?P<uid>[^)]+)\))?"
+        r"\s*:\s*(?P<reason>.+?)\s*$"
+    )
     for sid, body in deferred_section.items():
         for line in body.splitlines():
             m = line_re.match(line)
             if m:
                 out["deferred"].append({
                     "title": m.group("title").strip(),
-                    "uid": (m.group(2) or "").strip(),
+                    "uid": (m.group("uid") or "").strip(),
+                    "original_title": (m.group("orig") or "").strip(),
                     "reason": m.group("reason").strip(),
                     "session": sid,
                 })
@@ -249,7 +258,13 @@ def _render_session_sub(session_id_str, body):
 
 
 def _render_deferred_body(deferred_items):
-    """Turn a list of {title, uid, reason} dicts into the canonical markdown form.
+    """Turn a list of {title, uid, reason[, original_title]} dicts into
+    canonical markdown.
+
+    When `original_title` is present and differs from `title`, the rendered
+    line carries `(was: <original_title>)` so the plan→actual trace is visible
+    in the handoff without rerunning archives. Caller is responsible for
+    populating `original_title` from the task when building the dict.
 
     The parser in read_handoff() pairs with this format — keep them in sync.
     """
@@ -260,8 +275,10 @@ def _render_deferred_body(deferred_items):
         title = (item.get("title") or "").strip() or "(untitled)"
         uid = (item.get("uid") or "").strip()
         reason = (item.get("reason") or "").strip() or "(no reason given)"
+        orig = (item.get("original_title") or "").strip()
         uid_tag = f" ({uid})" if uid else ""
-        lines.append(f"- **{title}**{uid_tag}: {reason}")
+        was_tag = f" (was: {orig})" if orig and orig != title else ""
+        lines.append(f"- **{title}**{was_tag}{uid_tag}: {reason}")
     return "\n".join(lines)
 
 

--- a/bin/transition.py
+++ b/bin/transition.py
@@ -1644,6 +1644,46 @@ def cmd_remove(args):
                   config=load_config(), human_line=line)
 
 
+def cmd_rename(args):
+    """Rename a task. Preserves the very first title in `original_title`
+    so the planning framing survives even when the as-shipped title diverges.
+    Repeat renames update `title` only; `original_title` is set once.
+    """
+    session = load_session()
+    target, task = parse_task_target(args.target, session)
+
+    new_title = " ".join(args.title).strip()
+    if not new_title:
+        fail("New title is required.")
+
+    old_title = task.get("title", "")
+    if _title_matches(old_title, new_title):
+        fail(f"{tid(target)} title is already \"{old_title}\".")
+
+    echoed = getattr(args, "as_title", None)
+    if echoed is not None and not _title_matches(old_title, echoed):
+        emit_error(
+            f"--as echoed title does not match target task. "
+            f"Expected \"{old_title}\" (uid {task.get('uid')}), got \"{echoed}\".",
+            expected_title=old_title,
+            expected_uid=task.get("uid"),
+            echoed=echoed,
+            tid=tid(target),
+        )
+
+    if "original_title" not in task:
+        task["original_title"] = old_title
+    task["title"] = new_title
+
+    save_session(session)
+    render()
+
+    line = (f"\u270e {tid(target)} renamed: \"{old_title}\" \u2192 \"{new_title}\". "
+            f"[{remaining_summary(session)}]")
+    emit_mutation("rename", session, affected=[(target, task)],
+                  config=load_config(), human_line=line)
+
+
 def cmd_dispatch(args):
     """Mark a task as dispatched (being worked on in another session)."""
     session = load_session()
@@ -2790,6 +2830,22 @@ def build_parser():
              "(case-insensitive, whitespace-tolerant).",
     )
 
+    p_rename = sub.add_parser(
+        "rename",
+        help="Rename a task. Preserves the original title on first rename.",
+    )
+    p_rename.add_argument("target", help="Task ID (t3) or 0-based index (2).")
+    p_rename.add_argument("title", nargs="+", help="New task title.")
+    p_rename.add_argument(
+        "--as",
+        dest="as_title",
+        type=str,
+        default=None,
+        help="Echo the target task's CURRENT title. If provided, the CLI refuses "
+             "the mutation unless the echoed title matches "
+             "(case-insensitive, whitespace-tolerant).",
+    )
+
     p_move = sub.add_parser("move", help="Reorder a task.")
     p_move.add_argument("source", help="Task to move (t3 or 0-based index).")
     p_move.add_argument("--to", type=str, required=True, help="Destination: t2, top, end, or index.")
@@ -2925,6 +2981,7 @@ DISPATCH = {
     "defer": cmd_defer,
     "add": cmd_add,
     "remove": cmd_remove,
+    "rename": cmd_rename,
     "move": cmd_move,
     "switch": cmd_switch,
     "dispatch": cmd_dispatch,

--- a/docs/state-schema.md
+++ b/docs/state-schema.md
@@ -75,7 +75,8 @@ Tasks do NOT have an `id` field in JSON. Display IDs (`t1`, `t2`, ...) are deriv
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `title` | `string` | yes | Short description of the task. |
+| `title` | `string` | yes | Short description of the task. May be revised via `wpl rename` to reflect work-as-completed; the original is preserved in `original_title` on first rename. |
+| `original_title` | `string` | no | First-renamed title. Set automatically by `wpl rename` on the first rename only — repeat renames update `title` only, leaving `original_title` as the planning-phase receipt. Surfaced by `bin/handoff.py` as `(was: <original_title>)` in the deferred-with-reasons section when it differs from the current `title`. Absent on tasks that were never renamed — migration-safe. |
 | `status` | `string` | yes | Current task state: `pending`, `in_progress`, `done`, `blocked`, `deferred`. |
 | `estimate_min` | `integer` | yes | Estimated duration in minutes. |
 | `actual_min` | `integer \| null` | no | Actual duration in minutes. Set when task reaches `done`. |

--- a/docs/task-transitions.md
+++ b/docs/task-transitions.md
@@ -34,6 +34,7 @@ The `wpl` wrapper lives at `~/.workplanner/bin/wpl` and forwards to `bin/transit
 | `switch` | `<target> [--no-pause]` | Switch focus to a different task |
 | `dispatch` | `<target>` | Mark a task as dispatched to another session |
 | `remove` | `<target> [--as "<title>"]` | Remove a task entirely |
+| `rename` | `<target> <new-title...> [--as "<old-title>"]` | Update a task's title; preserves the original in `original_title` on first rename |
 | `status` | — | Print one-line status summary and full compact task list |
 
 ### Global flags
@@ -189,6 +190,15 @@ A `PostToolUse` plugin hook (`bin/post-tool-use-hook.sh`) provides a secondary f
 - **Auto-pauses** the previous `in_progress` task (sets it back to `pending`)
 - Use `--no-pause` to keep the previous task `in_progress` (for parallel/dispatched work)
 - Switching to a dispatched task (without `--no-pause`) **reclaims** it — clears the `dispatched` flag
+
+### rename
+
+- Updates the target task's `title` to the new value
+- On the **first** rename, copies the prior title into `original_title`; repeat renames update `title` only and leave `original_title` untouched (preserves the planning-phase framing for retrospection)
+- No-ops if the new title matches the current title (case-insensitive, whitespace-tolerant)
+- `--as "<old-title>"` echo-checks against the *current* title — useful when an LLM is renaming to confirm it's pointing at the task it thinks it is
+- Surfaces in the EOD handoff as `(was: <original_title>)` next to the deferred line when the two differ — no separate prompt; drift becomes visible in the artifact
+- Use this when execution reshapes a task and the title-as-typed reads as fiction; the goal is that a week-later reader sees the as-shipped framing without losing the plan trace
 
 ### dispatch
 


### PR DESCRIPTION
## Summary
- Adds `wpl rename <tid> <new-title>` and an `original_title` field (set on first rename only).
- Handoff renders `(was: <original_title>)` when current title diverges — drift visible in the artifact, no EOD prompt.
- Reader regex updated to round-trip the new format, including parens inside `(was: ...)`.

## Resolution path
Three-panel review on #42 converged on this minimum shape over the issue's two stated directions:
- **Rejected B** (`actual_summary` field): renderer would have to choose between fields = #6 violation; schema heavier than needed.
- **Rejected A-with-EOD-prompt**: wrong cognitive moment, weak churn signal, would be skipped or auto-affirmed.
- **Shipped A-minimal**: rename whenever it's needed during the day; the artifact (handoff) shows the drift without interrogation.

## Notes
- Issue #42's "archived JSON serves as the planning receipt" premise was wrong (sessions only archive at day-rollover, so in-session renames would lose the original). `original_title` lives on the task to fix that.
- No schema-version bump — `original_title` is optional and `.get()`-safe.

## Test plan
- [x] `rename --help` lists args
- [x] Same-title rename rejected with clear message
- [x] First rename sets `original_title`; repeat rename leaves `original_title` unchanged
- [x] `_render_deferred_body` emits `(was: ...)` only when `original_title != title`
- [x] Reader regex round-trips: title-with-parens, original-with-parens, no-uid, no-was, just-title

🤖 Generated with [Claude Code](https://claude.com/claude-code)